### PR TITLE
Use getValueFromAccessor fn to avoid repetitive user input

### DIFF
--- a/src/data-renderers/ListCard.js
+++ b/src/data-renderers/ListCard.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import { getValueFromAccessor } from './utils'
 
 /**
  * The component that is to be displayed within ListRenderer
@@ -23,7 +24,7 @@ export default class ListCard extends Component {
       return (
         <div className="objectlist-list__content" key={`list-item-${idx}`}>
           <h2 className="objectlist-list__header">{col.map(c => c.header).join(' ')}:</h2>
-          <div className="objectlist-list__body">{col.map(c => data[c.dataKey]).join(' ')}</div>
+          <div className="objectlist-list__body">{col.map(c => getValueFromAccessor(data, c.dataKey)).join(' ')}</div>
         </div>
       )
     })

--- a/src/data-renderers/Table.js
+++ b/src/data-renderers/Table.js
@@ -5,6 +5,7 @@ import TableHeader from './TableHeader'
 import Overlay from './Overlay'
 import {AllSelector, Selector} from '../types'
 import { getVisibleColumns, setColumnLabels } from '../utils/functions'
+import { getValueFromAccessor } from './utils'
 import { DATA_TYPE } from '../utils/constants'
 import { STATUS_TYPE, STATUS_CHOICES, SELECTION_TYPE, ALL_SELECTED } from '../utils/proptypes'
 
@@ -93,7 +94,7 @@ export default class TableRenderer extends Component {
                 RenderedItems.push(RenderItem.item({
                   row: row,
                   column: RenderItem,
-                  value: row[RenderItem.dataKey],
+                  value: getValueFromAccessor(row, RenderItem.dataKey),
                   key: `item-${i}`,
                 }))
               } else {

--- a/src/data-renderers/utils/__tests__/functions.test.js
+++ b/src/data-renderers/utils/__tests__/functions.test.js
@@ -10,4 +10,10 @@ describe('getValueFromAccessor', () => {
   it('returns value for a nested row/dotted key', () => {
     expect(getValueFromAccessor({a: {b: 'c'}}, 'a.b')).toBe('c')
   })
+  it('returns value up to point for incorrect key', () => {
+    expect(getValueFromAccessor({a: {b: 'c'}}, 'a.c')).toEqual({b: 'c'})
+  })
+  it('returns value without repetitive weirdness for incorrect key', () => {
+    expect(getValueFromAccessor({a: {b: 'c'}}, 'a.c.b')).toEqual({b: 'c'})
+  })
 })

--- a/src/data-renderers/utils/__tests__/functions.test.js
+++ b/src/data-renderers/utils/__tests__/functions.test.js
@@ -1,0 +1,13 @@
+import { getValueFromAccessor } from '../functions'
+
+describe('getValueFromAccessor', () => {
+  it('returns value for a simple key/row', () => {
+    expect(getValueFromAccessor({a: 'b'}, ['a'])).toBe('b')
+  })
+  it('returns value for a nested row/mutiple keys', () => {
+    expect(getValueFromAccessor({a: {b: 'c'}}, ['a', 'b'])).toBe('c')
+  })
+  it('returns value for a nested row/dotted key', () => {
+    expect(getValueFromAccessor({a: {b: 'c'}}, 'a.b')).toBe('c')
+  })
+})

--- a/src/data-renderers/utils/functions.js
+++ b/src/data-renderers/utils/functions.js
@@ -1,0 +1,22 @@
+/**
+ * Gets the value of the cell from the row and keys provided
+ * @param  {Object} row  Row supplied
+ * @param  {Array|string} keys List of keys used to access the value
+ * @return {(Object|string|number)}      Value from row, or row itself if no keys
+ */
+const getValueFromAccessor = (row, keys) => {
+  if (!Array.isArray(keys)) keys = keys.split('.')
+  let value = row
+  const cloneKeys = [...keys]
+  while (value && cloneKeys.length) {
+    const thisKey = cloneKeys.shift()
+    if (thisKey in value) {
+      value = value[thisKey]
+    }
+  }
+  return value
+}
+
+export {
+  getValueFromAccessor,
+}

--- a/src/data-renderers/utils/functions.js
+++ b/src/data-renderers/utils/functions.js
@@ -12,6 +12,8 @@ const getValueFromAccessor = (row, keys) => {
     const thisKey = cloneKeys.shift()
     if (thisKey in value) {
       value = value[thisKey]
+    } else {
+      return value
     }
   }
   return value

--- a/src/data-renderers/utils/index.js
+++ b/src/data-renderers/utils/index.js
@@ -1,0 +1,3 @@
+export {
+  getValueFromAccessor,
+} from './functions'


### PR DESCRIPTION
This is to avoid users having to define a custom `item` prop for each column with nested data
Instead can use dot notation: `levelone.leveltwo.thedataIwant`