### PR TITLE
Add bind for loadOptions to access this.value

### DIFF
--- a/src/actions-filters/FiltersContainer.js
+++ b/src/actions-filters/FiltersContainer.js
@@ -20,7 +20,7 @@ class FiltersContainer extends Component {
   }
 
   renderFilter = (filter, i) => {
-    const { Renderer, filterKey, value, ...props } = filter
+    const { Renderer, filterKey, loadOptions, value, ...props } = filter
     return (
       <Renderer
         key={`filter-${filterKey}-${i}`}
@@ -28,6 +28,7 @@ class FiltersContainer extends Component {
         value={value}
         onChange={this.props.updateFilter}
         removeFilter={this.props.removeFilter}
+        loadOptions={loadOptions ? loadOptions.bind(filter) : null}
         {...props}
       />
     )


### PR DESCRIPTION
allows `loadOptions` to make use of `filter.value` and `filter.url` when calling the endpoint to fetch the list of options.