### PR TITLE
Pass the entire object on a choice filter change

### DIFF
--- a/src/filters/types/Choice.js
+++ b/src/filters/types/Choice.js
@@ -46,17 +46,17 @@ class Choice extends React.Component {
    * @param  {object||object[]} newValue Just selected options
    */
   handleChange = newValue => {
-    const {onChange, valueKey, multi} = this.props
+    const {onChange, multi} = this.props
     if (!multi) {
       if (Array.isArray(newValue)) {
         newValue = newValue[0]
       }
-      onChange(newValue[valueKey])
+      onChange(newValue)
     } else {
       if (!Array.isArray(newValue)) {
         newValue = [newValue]
       }
-      onChange(newValue.map(x => x[valueKey]))
+      onChange(newValue)
     }
   }
 

--- a/src/filters/types/__tests__/Choice.test.js
+++ b/src/filters/types/__tests__/Choice.test.js
@@ -44,36 +44,42 @@ describe('Choice', () => {
       })
       describe('handles single choice', () => {
         it('receives single value', () => {
+          const newValue = {value: 5}
           const instance = shallow(<Choice {...baseProps} />).instance()
-          instance.handleChange({value: 5})
-          expect(baseProps.onChange).toHaveBeenCalledWith(5)
+          instance.handleChange(newValue)
+          expect(baseProps.onChange).toHaveBeenCalledWith(newValue)
         })
         it('receives array value', () => {
+          const newValue = [{value: 9}, {value: 5}]
           const instance = shallow(<Choice {...baseProps} />).instance()
-          instance.handleChange([{value: 9}, {value: 5}])
-          expect(baseProps.onChange).toHaveBeenCalledWith(9)
+          instance.handleChange(newValue)
+          expect(baseProps.onChange).toHaveBeenCalledWith(newValue[0])
         })
         it('has custom value key', () => {
+          const newValue = {bob: 67}
           const instance = shallow(<Choice {...baseProps} valueKey="bob" />).instance()
-          instance.handleChange({bob: 67})
-          expect(baseProps.onChange).toHaveBeenCalledWith(67)
+          instance.handleChange(newValue)
+          expect(baseProps.onChange).toHaveBeenCalledWith(newValue)
         })
       })
       describe('handles multiple choice', () => {
         it('receives array value', () => {
+          const newValue = [{value: 9}, {value: 5}]
           const instance = shallow(<Choice {...baseProps} multi />).instance()
-          instance.handleChange([{value: 9}, {value: 5}])
-          expect(baseProps.onChange).toHaveBeenCalledWith([9, 5])
+          instance.handleChange(newValue)
+          expect(baseProps.onChange).toHaveBeenCalledWith(newValue)
         })
         it('receives single value', () => {
+          const newValue = {value: 5}
           const instance = shallow(<Choice {...baseProps} multi />).instance()
-          instance.handleChange({value: 5})
-          expect(baseProps.onChange).toHaveBeenCalledWith([5])
+          instance.handleChange(newValue)
+          expect(baseProps.onChange).toHaveBeenCalledWith([newValue])
         })
         it('has custom value key', () => {
+          const newValue = [{bob: 67}]
           const instance = shallow(<Choice {...baseProps} multi valueKey="bob" />).instance()
-          instance.handleChange([{bob: 67}])
-          expect(baseProps.onChange).toHaveBeenCalledWith([67])
+          instance.handleChange(newValue)
+          expect(baseProps.onChange).toHaveBeenCalledWith(newValue)
         })
       })
     })


### PR DESCRIPTION
Instead of first extracting the value of the selected choice pass the entire object containing both the label and value. This is required when passing the value back into `react-select` as a currently selected option when we have a remote option list. Otherwise the component does not know what label to display for the currently selected item.