### PR TITLE
Fix/select

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,0 +1,1 @@
+import '@storybook/addon-actions/register'

--- a/src/data-renderers/Table.js
+++ b/src/data-renderers/Table.js
@@ -112,12 +112,23 @@ export default class TableRenderer extends Component {
     })
   }
 
+  allSelected = () => {
+    const {data, numSelected} = this.props
+    return !!(numSelected && numSelected >= data.length)
+  }
+
   handleToggleSelectAll = () => {
-    this.props.select(this.props.data.map(row => row.id))
+    const {data, select, selection} = this.props
+    const allSelected = this.allSelected()
+    if (allSelected) {
+      select(null)
+    } else {
+      select(data.map(row => row.id).filter(id => !(id in selection)))
+    }
   }
 
   render() {
-    const {data, select, numSelected, status} = this.props
+    const {select, status} = this.props
     return (
       <div className="objectlist-table--scroll">
         <Overlay status={status} />
@@ -127,7 +138,7 @@ export default class TableRenderer extends Component {
               {select && (
                 <th className="objectlist-table__th objectlist-table__th--selector">
                   <AllSelector
-                    allSelected={!!(numSelected && numSelected >= data.length)}
+                    allSelected={this.allSelected()}
                     toggleSelectAll={this.handleToggleSelectAll}
                   />
                 </th>

--- a/src/data-renderers/Table.js
+++ b/src/data-renderers/Table.js
@@ -119,8 +119,7 @@ export default class TableRenderer extends Component {
 
   handleToggleSelectAll = () => {
     const {data, select, selection} = this.props
-    const allSelected = this.allSelected()
-    if (allSelected) {
+    if (this.allSelected()) {
       select(null)
     } else {
       select(data.map(row => row.id).filter(id => !(id in selection)))

--- a/src/data-renderers/__tests__/Table.test.js
+++ b/src/data-renderers/__tests__/Table.test.js
@@ -37,11 +37,11 @@ describe('Table', () => {
     columnWidths: {'age_gender': {width: 50}},
     saveColumnWidth: jest.fn(),
     data: [
-      {type: 'Person', attributes: {name: 'Sam', age: '25', gender: 'M'}},
-      {type: 'Person', attributes: {name: 'Mary', age: '12', gender: 'F'}},
-      {type: 'Person', attributes: {name: 'Q', age: '3', gender: '?'}},
-      {type: 'Person', attributes: {name: 'Peter', age: '111', gender: 'FM'}},
-      {type: 'Person', attributes: {name: 'Amy', age: '32', gender: 'Confused'}},
+      {id: 1, type: 'Person', attributes: {name: 'Sam', age: '25', gender: 'M'}},
+      {id: 2, type: 'Person', attributes: {name: 'Mary', age: '12', gender: 'F'}},
+      {id: 3, type: 'Person', attributes: {name: 'Q', age: '3', gender: '?'}},
+      {id: 4, type: 'Person', attributes: {name: 'Peter', age: '111', gender: 'FM'}},
+      {id: 5, type: 'Person', attributes: {name: 'Amy', age: '32', gender: 'Confused'}},
     ],
   }
   describe('Snapshots', () => {
@@ -87,8 +87,36 @@ describe('Table', () => {
     it('handles select all', () => {
       spyOn(props, 'select')
       const instance = shallow(<Table {...props} />).instance()
+      expect(instance.allSelected()).toBe(false)
       instance.handleToggleSelectAll()
       expect(props.select).toHaveBeenCalledWith(props.data.map(row => row.id))
+    })
+    it('handles deselect all', () => {
+      spyOn(props, 'select')
+      const instance = shallow(
+        <Table
+          {...props}
+          numSelected={props.data.length}
+          selection={props.data.map(row => ({[row.id]: true}))}
+        />
+      ).instance()
+      expect(instance.allSelected()).toBe(true)
+      instance.handleToggleSelectAll()
+      expect(props.select).toHaveBeenCalledWith(null)
+    })
+    it('handles select remaining', () => {
+      spyOn(props, 'select')
+      const mockSelection = {1: true, 3: true}
+      const instance = shallow(
+        <Table
+          {...props}
+          numSelected={2}
+          selection={mockSelection}
+        />
+      ).instance()
+      expect(instance.allSelected()).toBe(false)
+      instance.handleToggleSelectAll()
+      expect(props.select).toHaveBeenCalledWith([2, 4, 5])
     })
   })
 })

--- a/src/data-renderers/__tests__/__snapshots__/Table.test.js.snap
+++ b/src/data-renderers/__tests__/__snapshots__/Table.test.js.snap
@@ -74,7 +74,7 @@ exports[`Table Snapshots can select items 1`] = `
           className="objectlist-table__td"
         >
           <Selector
-            id={undefined}
+            id={1}
             selected={false}
             toggleSelect={[MockFunction]}
           />
@@ -101,7 +101,7 @@ exports[`Table Snapshots can select items 1`] = `
           className="objectlist-table__td"
         >
           <Selector
-            id={undefined}
+            id={2}
             selected={false}
             toggleSelect={[MockFunction]}
           />
@@ -128,7 +128,7 @@ exports[`Table Snapshots can select items 1`] = `
           className="objectlist-table__td"
         >
           <Selector
-            id={undefined}
+            id={3}
             selected={false}
             toggleSelect={[MockFunction]}
           />
@@ -155,7 +155,7 @@ exports[`Table Snapshots can select items 1`] = `
           className="objectlist-table__td"
         >
           <Selector
-            id={undefined}
+            id={4}
             selected={false}
             toggleSelect={[MockFunction]}
           />
@@ -182,7 +182,7 @@ exports[`Table Snapshots can select items 1`] = `
           className="objectlist-table__td"
         >
           <Selector
-            id={undefined}
+            id={5}
             selected={false}
             toggleSelect={[MockFunction]}
           />


### PR DESCRIPTION
This changes the behaviour to match the previous list's select all button.
- If all selected, deselect all
- If all on page selected, deselect all
- If some selected, select remaining
- If none selected, select all on page