### PR TITLE
Add optional logarithmic and precision props to numberslider

### DIFF
--- a/src/__snapshots__/ObjectList.stories.storyshot
+++ b/src/__snapshots__/ObjectList.stories.storyshot
@@ -2241,8 +2241,9 @@ exports[`Storyshots object-list has active filters 1`] = `
             max={100}
             min={0}
             onChange={[Function]}
+            step={1}
             type="number"
-            value=""
+            value="0"
           />
           <input
             className="objectlist-input__number-slider--slider"
@@ -2250,8 +2251,9 @@ exports[`Storyshots object-list has active filters 1`] = `
             min={0}
             onChange={[Function]}
             onMouseUp={[Function]}
+            step="any"
             type="range"
-            value=""
+            value={0}
           />
         </div>
         <button
@@ -3575,8 +3577,9 @@ exports[`Storyshots object-list has everything 1`] = `
             max={100}
             min={0}
             onChange={[Function]}
+            step={1}
             type="number"
-            value=""
+            value="0"
           />
           <input
             className="objectlist-input__number-slider--slider"
@@ -3584,8 +3587,9 @@ exports[`Storyshots object-list has everything 1`] = `
             min={0}
             onChange={[Function]}
             onMouseUp={[Function]}
+            step="any"
             type="range"
-            value=""
+            value={0}
           />
         </div>
         <button

--- a/src/__snapshots__/ObjectList.stories.storyshot
+++ b/src/__snapshots__/ObjectList.stories.storyshot
@@ -2253,7 +2253,7 @@ exports[`Storyshots object-list has active filters 1`] = `
             onMouseUp={[Function]}
             step="any"
             type="range"
-            value={0}
+            value="0.0000000000"
           />
         </div>
         <button
@@ -3589,7 +3589,7 @@ exports[`Storyshots object-list has everything 1`] = `
             onMouseUp={[Function]}
             step="any"
             type="range"
-            value={0}
+            value="0.0000000000"
           />
         </div>
         <button

--- a/src/actions-filters/__snapshots__/ActionsFiltersContainer.stories.storyshot
+++ b/src/actions-filters/__snapshots__/ActionsFiltersContainer.stories.storyshot
@@ -600,7 +600,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
           onMouseUp={[Function]}
           step="any"
           type="range"
-          value={0}
+          value="0.0000000000"
         />
       </div>
       <button
@@ -1505,7 +1505,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
           onMouseUp={[Function]}
           step="any"
           type="range"
-          value={0}
+          value="0.0000000000"
         />
       </div>
       <button
@@ -2322,7 +2322,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
           onMouseUp={[Function]}
           step="any"
           type="range"
-          value={0}
+          value="0.0000000000"
         />
       </div>
       <button
@@ -3106,7 +3106,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
           onMouseUp={[Function]}
           step="any"
           type="range"
-          value={0}
+          value="0.0000000000"
         />
       </div>
       <button

--- a/src/actions-filters/__snapshots__/ActionsFiltersContainer.stories.storyshot
+++ b/src/actions-filters/__snapshots__/ActionsFiltersContainer.stories.storyshot
@@ -588,8 +588,9 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
           max={100}
           min={0}
           onChange={[Function]}
+          step={1}
           type="number"
-          value=""
+          value="0"
         />
         <input
           className="objectlist-input__number-slider--slider"
@@ -597,8 +598,9 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
           min={0}
           onChange={[Function]}
           onMouseUp={[Function]}
+          step="any"
           type="range"
-          value=""
+          value={0}
         />
       </div>
       <button
@@ -1491,8 +1493,9 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
           max={100}
           min={0}
           onChange={[Function]}
+          step={1}
           type="number"
-          value=""
+          value="0"
         />
         <input
           className="objectlist-input__number-slider--slider"
@@ -1500,8 +1503,9 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
           min={0}
           onChange={[Function]}
           onMouseUp={[Function]}
+          step="any"
           type="range"
-          value=""
+          value={0}
         />
       </div>
       <button
@@ -2306,8 +2310,9 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
           max={100}
           min={0}
           onChange={[Function]}
+          step={1}
           type="number"
-          value=""
+          value="0"
         />
         <input
           className="objectlist-input__number-slider--slider"
@@ -2315,8 +2320,9 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
           min={0}
           onChange={[Function]}
           onMouseUp={[Function]}
+          step="any"
           type="range"
-          value=""
+          value={0}
         />
       </div>
       <button
@@ -3088,8 +3094,9 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
           max={100}
           min={0}
           onChange={[Function]}
+          step={1}
           type="number"
-          value=""
+          value="0"
         />
         <input
           className="objectlist-input__number-slider--slider"
@@ -3097,8 +3104,9 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
           min={0}
           onChange={[Function]}
           onMouseUp={[Function]}
+          step="any"
           type="range"
-          value=""
+          value={0}
         />
       </div>
       <button

--- a/src/actions-filters/__snapshots__/FiltersContainer.stories.storyshot
+++ b/src/actions-filters/__snapshots__/FiltersContainer.stories.storyshot
@@ -527,7 +527,7 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
         onMouseUp={[Function]}
         step="any"
         type="range"
-        value={0}
+        value="0.0000000000"
       />
     </div>
     <button

--- a/src/actions-filters/__snapshots__/FiltersContainer.stories.storyshot
+++ b/src/actions-filters/__snapshots__/FiltersContainer.stories.storyshot
@@ -515,8 +515,9 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
         max={100}
         min={0}
         onChange={[Function]}
+        step={1}
         type="number"
-        value=""
+        value="0"
       />
       <input
         className="objectlist-input__number-slider--slider"
@@ -524,8 +525,9 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
         min={0}
         onChange={[Function]}
         onMouseUp={[Function]}
+        step="any"
         type="range"
-        value=""
+        value={0}
       />
     </div>
     <button

--- a/src/filters/__snapshots__/filters.stories.storyshot
+++ b/src/filters/__snapshots__/filters.stories.storyshot
@@ -509,78 +509,6 @@ exports[`Storyshots object-list/Filters MultiChoiceFilter 1`] = `
 </div>
 `;
 
-exports[`Storyshots object-list/Filters NumberSliderFilter 1`] = `
-<div
-  className="objectlist-row"
->
-  <label
-    className="objectlist-current-filter__filter-name"
-  >
-    Filter by
-    :
-  </label>
-  <div
-    className="objectlist-current-filter__filter-comparison"
-  >
-    <Select
-      clearable={false}
-      onChange={[Function]}
-      options={
-        Array [
-          Object {
-            "label": "Exact",
-            "value": "exact",
-          },
-          Object {
-            "label": "Greater than",
-            "value": "gt",
-          },
-          Object {
-            "label": "Less than",
-            "value": "lt",
-          },
-          Object {
-            "label": "Greater than or equal",
-            "value": "gte",
-          },
-          Object {
-            "label": "Less than or equal",
-            "value": "lte",
-          },
-        ]
-      }
-      value="exact"
-    />
-  </div>
-  <div
-    className="objectlist-row objectlist-current-filter__active-status"
-  >
-    <input
-      className="objectlist-input objectlist-input__number-slider--number"
-      max={100}
-      min={0}
-      onChange={[Function]}
-      type="number"
-      value={45}
-    />
-    <input
-      className="objectlist-input__number-slider--slider"
-      max={100}
-      min={0}
-      onChange={[Function]}
-      onMouseUp={[Function]}
-      type="range"
-      value={45}
-    />
-  </div>
-  <button
-    className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
-    onClick={[Function]}
-    title="Remove Filter"
-  />
-</div>
-`;
-
 exports[`Storyshots object-list/Filters RemoteChoiceFilter 1`] = `
 <div
   className="objectlist-row"
@@ -719,6 +647,302 @@ exports[`Storyshots object-list/Filters TextContainsFilter 1`] = `
     type="text"
     value=""
   />
+  <button
+    className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
+    onClick={[Function]}
+    title="Remove Filter"
+  />
+</div>
+`;
+
+exports[`Storyshots object-list/Filters/NumberSliderFilter Decimal logarithmic with fixed range 1`] = `
+<div
+  className="objectlist-row"
+>
+  <label
+    className="objectlist-current-filter__filter-name"
+  >
+    Filter by
+    :
+  </label>
+  <div
+    className="objectlist-current-filter__filter-comparison"
+  >
+    <Select
+      clearable={false}
+      onChange={[Function]}
+      options={
+        Array [
+          Object {
+            "label": "Exact",
+            "value": "exact",
+          },
+          Object {
+            "label": "Greater than",
+            "value": "gt",
+          },
+          Object {
+            "label": "Less than",
+            "value": "lt",
+          },
+          Object {
+            "label": "Greater than or equal",
+            "value": "gte",
+          },
+          Object {
+            "label": "Less than or equal",
+            "value": "lte",
+          },
+        ]
+      }
+      value="exact"
+    />
+  </div>
+  <div
+    className="objectlist-row objectlist-current-filter__active-status"
+  >
+    <input
+      className="objectlist-input objectlist-input__number-slider--number"
+      max={25}
+      min={20}
+      onChange={[Function]}
+      step={0.1}
+      type="number"
+      value="21.5"
+    />
+    <input
+      className="objectlist-input__number-slider--slider"
+      max={25}
+      min={20}
+      onChange={[Function]}
+      onMouseUp={[Function]}
+      step="any"
+      type="range"
+      value={22.841008620334975}
+    />
+  </div>
+  <button
+    className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
+    onClick={[Function]}
+    title="Remove Filter"
+  />
+</div>
+`;
+
+exports[`Storyshots object-list/Filters/NumberSliderFilter Decimal with fixed range 1`] = `
+<div
+  className="objectlist-row"
+>
+  <label
+    className="objectlist-current-filter__filter-name"
+  >
+    Filter by
+    :
+  </label>
+  <div
+    className="objectlist-current-filter__filter-comparison"
+  >
+    <Select
+      clearable={false}
+      onChange={[Function]}
+      options={
+        Array [
+          Object {
+            "label": "Exact",
+            "value": "exact",
+          },
+          Object {
+            "label": "Greater than",
+            "value": "gt",
+          },
+          Object {
+            "label": "Less than",
+            "value": "lt",
+          },
+          Object {
+            "label": "Greater than or equal",
+            "value": "gte",
+          },
+          Object {
+            "label": "Less than or equal",
+            "value": "lte",
+          },
+        ]
+      }
+      value="exact"
+    />
+  </div>
+  <div
+    className="objectlist-row objectlist-current-filter__active-status"
+  >
+    <input
+      className="objectlist-input objectlist-input__number-slider--number"
+      max={25}
+      min={20}
+      onChange={[Function]}
+      step={0.1}
+      type="number"
+      value="21.5"
+    />
+    <input
+      className="objectlist-input__number-slider--slider"
+      max={25}
+      min={20}
+      onChange={[Function]}
+      onMouseUp={[Function]}
+      step="any"
+      type="range"
+      value={21.5}
+    />
+  </div>
+  <button
+    className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
+    onClick={[Function]}
+    title="Remove Filter"
+  />
+</div>
+`;
+
+exports[`Storyshots object-list/Filters/NumberSliderFilter Logarithmic 1`] = `
+<div
+  className="objectlist-row"
+>
+  <label
+    className="objectlist-current-filter__filter-name"
+  >
+    Filter by
+    :
+  </label>
+  <div
+    className="objectlist-current-filter__filter-comparison"
+  >
+    <Select
+      clearable={false}
+      onChange={[Function]}
+      options={
+        Array [
+          Object {
+            "label": "Exact",
+            "value": "exact",
+          },
+          Object {
+            "label": "Greater than",
+            "value": "gt",
+          },
+          Object {
+            "label": "Less than",
+            "value": "lt",
+          },
+          Object {
+            "label": "Greater than or equal",
+            "value": "gte",
+          },
+          Object {
+            "label": "Less than or equal",
+            "value": "lte",
+          },
+        ]
+      }
+      value="exact"
+    />
+  </div>
+  <div
+    className="objectlist-row objectlist-current-filter__active-status"
+  >
+    <input
+      className="objectlist-input objectlist-input__number-slider--number"
+      max={100}
+      min={0}
+      onChange={[Function]}
+      step={1}
+      type="number"
+      value="45"
+    />
+    <input
+      className="objectlist-input__number-slider--slider"
+      max={100}
+      min={0}
+      onChange={[Function]}
+      onMouseUp={[Function]}
+      step="any"
+      type="range"
+      value={70.32913781186613}
+    />
+  </div>
+  <button
+    className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
+    onClick={[Function]}
+    title="Remove Filter"
+  />
+</div>
+`;
+
+exports[`Storyshots object-list/Filters/NumberSliderFilter Standard 1`] = `
+<div
+  className="objectlist-row"
+>
+  <label
+    className="objectlist-current-filter__filter-name"
+  >
+    Filter by
+    :
+  </label>
+  <div
+    className="objectlist-current-filter__filter-comparison"
+  >
+    <Select
+      clearable={false}
+      onChange={[Function]}
+      options={
+        Array [
+          Object {
+            "label": "Exact",
+            "value": "exact",
+          },
+          Object {
+            "label": "Greater than",
+            "value": "gt",
+          },
+          Object {
+            "label": "Less than",
+            "value": "lt",
+          },
+          Object {
+            "label": "Greater than or equal",
+            "value": "gte",
+          },
+          Object {
+            "label": "Less than or equal",
+            "value": "lte",
+          },
+        ]
+      }
+      value="exact"
+    />
+  </div>
+  <div
+    className="objectlist-row objectlist-current-filter__active-status"
+  >
+    <input
+      className="objectlist-input objectlist-input__number-slider--number"
+      max={100}
+      min={0}
+      onChange={[Function]}
+      step={1}
+      type="number"
+      value="45"
+    />
+    <input
+      className="objectlist-input__number-slider--slider"
+      max={100}
+      min={0}
+      onChange={[Function]}
+      onMouseUp={[Function]}
+      step="any"
+      type="range"
+      value={45}
+    />
+  </div>
   <button
     className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
     onClick={[Function]}

--- a/src/filters/__snapshots__/filters.stories.storyshot
+++ b/src/filters/__snapshots__/filters.stories.storyshot
@@ -872,6 +872,7 @@ exports[`Storyshots object-list/Filters/NumberSliderFilter Logarithmic 1`] = `
   <button
     className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
     onClick={[Function]}
+    title="Remove Filter"
   />
 </div>
 `;
@@ -945,6 +946,7 @@ exports[`Storyshots object-list/Filters/NumberSliderFilter Logarithmic with diff
   <button
     className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
     onClick={[Function]}
+    title="Remove Filter"
   />
 </div>
 `;

--- a/src/filters/__snapshots__/filters.stories.storyshot
+++ b/src/filters/__snapshots__/filters.stories.storyshot
@@ -718,7 +718,7 @@ exports[`Storyshots object-list/Filters/NumberSliderFilter Decimal logarithmic w
       onMouseUp={[Function]}
       step="any"
       type="range"
-      value={22.841008620334975}
+      value="22.8410086203"
     />
   </div>
   <button
@@ -792,7 +792,7 @@ exports[`Storyshots object-list/Filters/NumberSliderFilter Decimal with fixed ra
       onMouseUp={[Function]}
       step="any"
       type="range"
-      value={21.5}
+      value="21.5000000000"
     />
   </div>
   <button
@@ -866,7 +866,153 @@ exports[`Storyshots object-list/Filters/NumberSliderFilter Logarithmic 1`] = `
       onMouseUp={[Function]}
       step="any"
       type="range"
-      value={70.32913781186613}
+      value="70.3291378119"
+    />
+  </div>
+  <button
+    className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
+    onClick={[Function]}
+  />
+</div>
+`;
+
+exports[`Storyshots object-list/Filters/NumberSliderFilter Logarithmic with different base 1`] = `
+<div
+  className="objectlist-row"
+>
+  <label
+    className="objectlist-current-filter__filter-name"
+  >
+    Filter by
+    :
+  </label>
+  <div
+    className="objectlist-current-filter__filter-comparison"
+  >
+    <Select
+      clearable={false}
+      onChange={[Function]}
+      options={
+        Array [
+          Object {
+            "label": "Exact",
+            "value": "exact",
+          },
+          Object {
+            "label": "Greater than",
+            "value": "gt",
+          },
+          Object {
+            "label": "Less than",
+            "value": "lt",
+          },
+          Object {
+            "label": "Greater than or equal",
+            "value": "gte",
+          },
+          Object {
+            "label": "Less than or equal",
+            "value": "lte",
+          },
+        ]
+      }
+      value="exact"
+    />
+  </div>
+  <div
+    className="objectlist-row objectlist-current-filter__active-status"
+  >
+    <input
+      className="objectlist-input objectlist-input__number-slider--number"
+      max={100}
+      min={0}
+      onChange={[Function]}
+      step={1}
+      type="number"
+      value="25"
+    />
+    <input
+      className="objectlist-input__number-slider--slider"
+      max={100}
+      min={0}
+      onChange={[Function]}
+      onMouseUp={[Function]}
+      step="any"
+      type="range"
+      value="35.7374019509"
+    />
+  </div>
+  <button
+    className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
+    onClick={[Function]}
+  />
+</div>
+`;
+
+exports[`Storyshots object-list/Filters/NumberSliderFilter Negative decimal logarithmic with fixed range 1`] = `
+<div
+  className="objectlist-row"
+>
+  <label
+    className="objectlist-current-filter__filter-name"
+  >
+    Filter by
+    :
+  </label>
+  <div
+    className="objectlist-current-filter__filter-comparison"
+  >
+    <Select
+      clearable={false}
+      onChange={[Function]}
+      options={
+        Array [
+          Object {
+            "label": "Exact",
+            "value": "exact",
+          },
+          Object {
+            "label": "Greater than",
+            "value": "gt",
+          },
+          Object {
+            "label": "Less than",
+            "value": "lt",
+          },
+          Object {
+            "label": "Greater than or equal",
+            "value": "gte",
+          },
+          Object {
+            "label": "Less than or equal",
+            "value": "lte",
+          },
+        ]
+      }
+      value="exact"
+    />
+  </div>
+  <div
+    className="objectlist-row objectlist-current-filter__active-status"
+  >
+    <input
+      className="objectlist-input objectlist-input__number-slider--number"
+      max={0}
+      min={-0.2}
+      onChange={[Function]}
+      step={0.01}
+      type="number"
+      value="-0.15"
+    />
+    <input
+      className="objectlist-input__number-slider--slider"
+      max={0}
+      min={-0.2}
+      onChange={[Function]}
+      onMouseUp={[Function]}
+      step="any"
+      type="range"
+      value="-0.0976233278"
     />
   </div>
   <button
@@ -940,7 +1086,7 @@ exports[`Storyshots object-list/Filters/NumberSliderFilter Standard 1`] = `
       onMouseUp={[Function]}
       step="any"
       type="range"
-      value={45}
+      value="45.0000000000"
     />
   </div>
   <button

--- a/src/filters/filters.stories.js
+++ b/src/filters/filters.stories.js
@@ -66,14 +66,6 @@ storiesOf('object-list/Filters', module)
       value={Moment(1519809160079)}
     />
   ))
-  .add('NumberSliderFilter', () => (
-    <NumberSliderFilter
-      {...baseProps}
-      name="Filter by"
-      filterKey="filterkey"
-      value={45}
-    />
-  ))
   .add('RemoteChoiceFilter', () => (
     <RemoteChoiceFilter
       {...baseProps}
@@ -128,5 +120,50 @@ storiesOf('object-list/Filters', module)
       {...baseProps}
       name="Filter by"
       filterKey="filterkey"
+    />
+  ))
+
+storiesOf('object-list/Filters/NumberSliderFilter', module)
+  .addDecorator((story, context) => withInfo(
+    'Number Slider filter user to select any number in a range'
+  )(story)(context))
+  .add('Standard', () => (
+    <NumberSliderFilter
+      {...baseProps}
+      name="Filter by"
+      filterKey="filterkey"
+      value={45}
+    />
+  ))
+  .add('Decimal with fixed range', () => (
+    <NumberSliderFilter
+      {...baseProps}
+      name="Filter by"
+      filterKey="filterkey"
+      value={21.5}
+      precision={1}
+      min={20}
+      max={25}
+    />
+  ))
+  .add('Logarithmic', () => (
+    <NumberSliderFilter
+      {...baseProps}
+      name="Filter by"
+      filterKey="filterkey"
+      value={45}
+      logarithmic
+    />
+  ))
+  .add('Decimal logarithmic with fixed range', () => (
+    <NumberSliderFilter
+      {...baseProps}
+      name="Filter by"
+      filterKey="filterkey"
+      logarithmic
+      value={21.5}
+      precision={1}
+      min={20}
+      max={25}
     />
   ))

--- a/src/filters/filters.stories.js
+++ b/src/filters/filters.stories.js
@@ -167,3 +167,25 @@ storiesOf('object-list/Filters/NumberSliderFilter', module)
       max={25}
     />
   ))
+  .add('Negative decimal logarithmic with fixed range', () => (
+    <NumberSliderFilter
+      {...baseProps}
+      name="Filter by"
+      filterKey="filterkey"
+      logarithmic
+      value={-0.15}
+      precision={2}
+      min={-0.2}
+      max={0}
+    />
+  ))
+  .add('Logarithmic with different base', () => (
+    <NumberSliderFilter
+      {...baseProps}
+      name="Filter by"
+      filterKey="filterkey"
+      logarithmic
+      value={25}
+      logbase={Math.E}
+    />
+  ))

--- a/src/filters/types/NumberSlider.js
+++ b/src/filters/types/NumberSlider.js
@@ -17,6 +17,8 @@ class NumberSlider extends React.Component {
     onChange: PropTypes.func,
     /** True if logarithmic value increase enabled */
     logarithmic: PropTypes.bool,
+    /** Base to use for logarithmic increase */
+    logbase: PropTypes.number,
     /** Decimal places allowed */
     precision: PropTypes.number,
   }
@@ -26,6 +28,7 @@ class NumberSlider extends React.Component {
     min: 0,
     max: 100,
     logarithmic: false,
+    logbase: 10,
     precision: 0,
   }
 
@@ -90,12 +93,12 @@ class NumberSlider extends React.Component {
    * @return {number}       Number stored in state
    */
   getValueFromSlider = input => {
-    const {min, max, logarithmic} = this.props
+    const {min, max, logarithmic, logbase} = this.props
     let value = parseFloat(input)
     if (logarithmic) {
       const range = max - min
       const fractionAlongSlider = (value - min) / range
-      value = (range * ((10 ** fractionAlongSlider) - 1) / (10 - 1)) + min
+      value = (range * ((logbase ** fractionAlongSlider) - 1) / (logbase - 1)) + min
     }
     return value
   }
@@ -107,11 +110,12 @@ class NumberSlider extends React.Component {
    * @return {number}       Value translated for slider
    */
   getValueForSlider = input => {
-    const {min, max, logarithmic} = this.props
+    const {min, max, logarithmic, logbase} = this.props
     let value = parseFloat(input)
     if (logarithmic) {
+      const logConst = 1 / Math.log(this.props.logbase)
       const range = max - min
-      value = min + (range * Math.log10(((value - min) * (10 - 1) / range) + 1))
+      value = min + (range * logConst * Math.log(((value - min) * (logbase - 1) / range) + 1))
     }
     return value
   }
@@ -133,6 +137,7 @@ class NumberSlider extends React.Component {
     const {currentValue, sliderValue} = this.state
     const step = 1 / (10 ** (precision))
     const display = currentValue.toFixed(precision)
+    const sliderRoundedValue = parseFloat(sliderValue).toFixed(10)
     return (
       <div className="objectlist-row objectlist-current-filter__active-status">
         <input
@@ -147,7 +152,7 @@ class NumberSlider extends React.Component {
         <input
           type="range"
           className="objectlist-input__number-slider--slider"
-          value={sliderValue}
+          value={sliderRoundedValue}
           onChange={this.handleSliderValueChange}
           onMouseUp={this.handleSliderValueFinalise}
           step="any"

--- a/src/filters/types/NumberSlider.js
+++ b/src/filters/types/NumberSlider.js
@@ -15,16 +15,27 @@ class NumberSlider extends React.Component {
     value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     /** Function to call when value changed */
     onChange: PropTypes.func,
+    /** True if logarithmic value increase enabled */
+    logarithmic: PropTypes.bool,
+    /** Decimal places allowed */
+    precision: PropTypes.number,
   }
 
   static defaultProps = {
     value: '',
     min: 0,
     max: 100,
+    logarithmic: false,
+    precision: 0,
   }
 
-  state = {
-    currentValue: this.props.value,
+  constructor(props) {
+    super(props)
+    this.state = {
+      ...this.state,
+      currentValue: props.value || props.min,
+      sliderValue: props.value ? this.getValueForSlider(props.value) : props.min,
+    }
   }
 
   componentWillReceiveProps(nextProps) {
@@ -36,14 +47,73 @@ class NumberSlider extends React.Component {
   /**
    * Handles number input change.
    * Calls onChange with the current value.
-   * @param  {Object} input Input object
-   * @param {number}  input.value Integer
+   * @param  {event} event onChange event object
    */
   handleValueChange = (event) => {
-    const newValue = event.target.value
+    const {precision} = this.props
+    const value = parseFloat(event.target.value)
     this.setState(
-      () => ({currentValue: newValue}), this.props.onChange(newValue)
+      () => ({
+        currentValue: value,
+        sliderValue: this.getValueForSlider(value),
+      }), () => {
+        const roundedValue = value.toFixed(precision)
+        this.props.onChange(roundedValue)
+      }
     )
+  }
+
+  /**
+   * Handles slider onMouseUp.
+   * Calls onChange with the current translated value.
+   * @param  {event} event onMouseUp event object
+   */
+  handleSliderValueFinalise = (event) => {
+    const {precision} = this.props
+    const value = parseFloat(event.target.value)
+    const finalValue = this.getValueFromSlider(value)
+    this.setState(
+      () => ({
+        currentValue: finalValue,
+        sliderValue: value,
+      }), () => {
+        const roundedValue = finalValue.toFixed(precision)
+        this.props.onChange(roundedValue)
+      }
+    )
+  }
+
+  /**
+   * Translates slider event value into valid output value
+   * If not using logarithmic, this will be the same
+   * @param  {number} input Number returned by slider
+   * @return {number}       Number stored in state
+   */
+  getValueFromSlider = input => {
+    const {min, max, logarithmic} = this.props
+    let value = parseFloat(input)
+    if (logarithmic) {
+      const range = max - min
+      const fractionAlongSlider = (value - min) / range
+      value = (range * ((10 ** fractionAlongSlider) - 1) / (10 - 1)) + min
+    }
+    return value
+  }
+
+  /**
+   * Translates current value into a slider value
+   * If not using logarithmic this will be the same
+   * @param  {number} input Actual value
+   * @return {number}       Value translated for slider
+   */
+  getValueForSlider = input => {
+    const {min, max, logarithmic} = this.props
+    let value = parseFloat(input)
+    if (logarithmic) {
+      const range = max - min
+      value = min + (range * Math.log10(((value - min) * (10 - 1) / range) + 1))
+    }
+    return value
   }
 
   /**
@@ -51,29 +121,38 @@ class NumberSlider extends React.Component {
    * Sets state to final value
    */
   handleSliderValueChange = (event) => {
-    const newValue = event.target.value
-    this.setState(() => ({currentValue: newValue}))
+    const value = event.target.value
+    this.setState(() => ({
+      currentValue: this.getValueFromSlider(value),
+      sliderValue: value,
+    }))
   }
 
   render() {
+    const {min, max, precision} = this.props
+    const {currentValue, sliderValue} = this.state
+    const step = 1 / (10 ** (precision))
+    const display = currentValue.toFixed(precision)
     return (
       <div className="objectlist-row objectlist-current-filter__active-status">
         <input
           type="number"
           className="objectlist-input objectlist-input__number-slider--number"
-          min={this.props.min}
-          max={this.props.max}
-          value={this.state.currentValue}
+          min={min}
+          max={max}
+          value={display}
           onChange={this.handleValueChange}
+          step={step}
         />
         <input
           type="range"
           className="objectlist-input__number-slider--slider"
-          value={this.state.currentValue}
+          value={sliderValue}
           onChange={this.handleSliderValueChange}
-          onMouseUp={this.handleValueChange}
-          min={this.props.min}
-          max={this.props.max}
+          onMouseUp={this.handleSliderValueFinalise}
+          step="any"
+          min={min}
+          max={max}
         />
       </div>
     )

--- a/src/filters/types/__tests__/NumberSlider.test.js
+++ b/src/filters/types/__tests__/NumberSlider.test.js
@@ -7,6 +7,7 @@ describe('NumberSlider', () => {
   const baseProps = {
     onChange: jest.fn(),
     value: 50,
+    precision: 1,
   }
   describe('Snapshots', () => {
     it('renders default', () => {
@@ -55,7 +56,24 @@ describe('NumberSlider', () => {
       }
       instance.handleValueChange(mockEvent)
       expect(instance.state.currentValue).toBe(mockValue)
-      expect(baseProps.onChange).toHaveBeenCalledWith(mockValue)
+      expect(baseProps.onChange).toHaveBeenCalledWith(mockValue.toFixed(1))
+    })
+    it('handles slider value finalise', () => {
+      const mockValue = Math.floor(Math.random() * 100) + 1
+      const mockEvent = {
+        target: {
+          value: mockValue,
+        },
+      }
+      instance.handleSliderValueFinalise(mockEvent)
+      expect(instance.state.currentValue).toBe(mockValue)
+      expect(baseProps.onChange).toHaveBeenCalledWith(mockValue.toFixed(1))
+    })
+    it('handles logarithmic translation', () => {
+      const mockValue = Math.floor(Math.random() * 100) + 1
+      instance = shallow(<NumberSlider {...baseProps} logarithmic />).instance()
+      const actualValue = instance.getValueFromSlider(mockValue)
+      expect(instance.getValueForSlider(actualValue)).toBe(mockValue)
     })
   })
 })

--- a/src/filters/types/__tests__/NumberSlider.test.js
+++ b/src/filters/types/__tests__/NumberSlider.test.js
@@ -73,7 +73,7 @@ describe('NumberSlider', () => {
       const mockValue = Math.floor(Math.random() * 100) + 1
       instance = shallow(<NumberSlider {...baseProps} logarithmic />).instance()
       const actualValue = instance.getValueFromSlider(mockValue)
-      expect(instance.getValueForSlider(actualValue)).toBe(mockValue)
+      expect(instance.getValueForSlider(actualValue)).toBeCloseTo(mockValue, 10)
     })
   })
 })

--- a/src/filters/types/__tests__/__snapshots__/NumberSlider.test.js.snap
+++ b/src/filters/types/__tests__/__snapshots__/NumberSlider.test.js.snap
@@ -21,7 +21,7 @@ exports[`NumberSlider Snapshots custom max 1`] = `
     onMouseUp={[Function]}
     step="any"
     type="range"
-    value={50}
+    value="50.0000000000"
   />
 </div>
 `;
@@ -47,7 +47,7 @@ exports[`NumberSlider Snapshots custom min 1`] = `
     onMouseUp={[Function]}
     step="any"
     type="range"
-    value={50}
+    value="50.0000000000"
   />
 </div>
 `;
@@ -73,7 +73,7 @@ exports[`NumberSlider Snapshots renders default 1`] = `
     onMouseUp={[Function]}
     step="any"
     type="range"
-    value={50}
+    value="50.0000000000"
   />
 </div>
 `;

--- a/src/filters/types/__tests__/__snapshots__/NumberSlider.test.js.snap
+++ b/src/filters/types/__tests__/__snapshots__/NumberSlider.test.js.snap
@@ -9,8 +9,9 @@ exports[`NumberSlider Snapshots custom max 1`] = `
     max={2000}
     min={0}
     onChange={[Function]}
+    step={0.1}
     type="number"
-    value={50}
+    value="50.0"
   />
   <input
     className="objectlist-input__number-slider--slider"
@@ -18,6 +19,7 @@ exports[`NumberSlider Snapshots custom max 1`] = `
     min={0}
     onChange={[Function]}
     onMouseUp={[Function]}
+    step="any"
     type="range"
     value={50}
   />
@@ -33,8 +35,9 @@ exports[`NumberSlider Snapshots custom min 1`] = `
     max={100}
     min={30}
     onChange={[Function]}
+    step={0.1}
     type="number"
-    value={50}
+    value="50.0"
   />
   <input
     className="objectlist-input__number-slider--slider"
@@ -42,6 +45,7 @@ exports[`NumberSlider Snapshots custom min 1`] = `
     min={30}
     onChange={[Function]}
     onMouseUp={[Function]}
+    step="any"
     type="range"
     value={50}
   />
@@ -57,8 +61,9 @@ exports[`NumberSlider Snapshots renders default 1`] = `
     max={100}
     min={0}
     onChange={[Function]}
+    step={0.1}
     type="number"
-    value={50}
+    value="50.0"
   />
   <input
     className="objectlist-input__number-slider--slider"
@@ -66,6 +71,7 @@ exports[`NumberSlider Snapshots renders default 1`] = `
     min={0}
     onChange={[Function]}
     onMouseUp={[Function]}
+    step="any"
     type="range"
     value={50}
   />


### PR DESCRIPTION
- Allows finer choice of small numbers if `logarithmic` prop is passed
- Can override base 10 with whatever base you want using `logbase` prop
- Support for decimals with `precision` prop which indicates number of decimal places