### PR TITLE
Upgrade to react-select v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ styles/
 coverage/
 .vscode/
 .DS_Store
+**~

--- a/__mocks__/react-select.js
+++ b/__mocks__/react-select.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
+jest.mock('react-select/lib/Async', () => 'Select.Async')
+
 const Select = props => React.createElement('Select', props, props.children)
 Select.Async = 'Select.Async'
 /* eslint-disable-next-line */

--- a/demo-site/package.json
+++ b/demo-site/package.json
@@ -25,7 +25,7 @@
     "react-dom": "^16.2.0",
     "react-month-picker": "^1.3.5",
     "react-object-list": "^0.0.9",
-    "react-select": "^1.2.1",
+    "react-select": "^2.0.0-beta.6",
     "uptick-demo-site": "latest"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "publish-demo": "git branch -D gh-pages; git push origin --delete gh-pages; git checkout -b gh-pages; cd demo-site; yarn; npm run build; cd ..; git add .; git add -f demo-site/dist; git add -f demo-site/node_modules/uptick-demo-site/dist; git commit -m \"Demo site build\"; git push origin gh-pages; git checkout master; git push origin `git subtree split --prefix demo-site gh-pages`:gh-pages --force;",
     "build": "webpack --mode production",
     "dev": "webpack --mode development",
+    "watch": "webpack --mode development --watch",
     "test": "jest",
     "storybook": "start-storybook -p 9001 -c .storybook",
     "prepublish": "mkdir -p styles && cp src/*.sass styles"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "react-day-picker": "^7.1.1",
     "react-dom": "^16.2.0",
     "react-month-picker": "^1.3.5",
-    "react-select": "^1.2.1",
+    "react-select": "^2.0.0-beta.6",
     "react-test-renderer": "^16.2.0",
     "resolve-url-loader": "^2.3.0",
     "sass-loader": "^6.0.7",
@@ -86,6 +86,6 @@
     "react-day-picker": "^7.1.1",
     "react-dom": "15.x - 16.x",
     "react-month-picker": "^1.3.5",
-    "react-select": "^1.2.1"
+    "react-select": "^2.0.0-beta.6"
   }
 }

--- a/src/__snapshots__/ObjectList.demo.stories.storyshot
+++ b/src/__snapshots__/ObjectList.demo.stories.storyshot
@@ -26,19 +26,10 @@ exports[`Storyshots object-list/demo interactive list 1`] = `
       >
         <Select
           className="objectlist-select-filter"
-          labelKey="name"
-          menuContainerStyle={
-            Object {
-              "maxHeight": "500px",
-            }
-          }
-          menuStyle={
-            Object {
-              "maxHeight": "500px",
-            }
-          }
+          getOptionLabel={[Function]}
+          getOptionValue={[Function]}
           onChange={[Function]}
-          openOnFocus={true}
+          openMenuOnClick={true}
           options={
             Array [
               Object {
@@ -50,8 +41,13 @@ exports[`Storyshots object-list/demo interactive list 1`] = `
             ]
           }
           placeholder="Add Filter"
+          styles={
+            Object {
+              "menu": [Function],
+              "menuList": [Function],
+            }
+          }
           value={null}
-          valueKey="filterKey"
         />
       </div>
     </div>
@@ -640,19 +636,10 @@ exports[`Storyshots object-list/demo interactive table 1`] = `
       >
         <Select
           className="objectlist-select-filter"
-          labelKey="name"
-          menuContainerStyle={
-            Object {
-              "maxHeight": "500px",
-            }
-          }
-          menuStyle={
-            Object {
-              "maxHeight": "500px",
-            }
-          }
+          getOptionLabel={[Function]}
+          getOptionValue={[Function]}
           onChange={[Function]}
-          openOnFocus={true}
+          openMenuOnClick={true}
           options={
             Array [
               Object {
@@ -664,8 +651,13 @@ exports[`Storyshots object-list/demo interactive table 1`] = `
             ]
           }
           placeholder="Add Filter"
+          styles={
+            Object {
+              "menu": [Function],
+              "menuList": [Function],
+            }
+          }
           value={null}
-          valueKey="filterKey"
         />
       </div>
     </div>

--- a/src/__snapshots__/ObjectList.demo.stories.storyshot
+++ b/src/__snapshots__/ObjectList.demo.stories.storyshot
@@ -43,8 +43,10 @@ exports[`Storyshots object-list/demo interactive list 1`] = `
           placeholder="Add Filter"
           styles={
             Object {
-              "menu": [Function],
-              "menuList": [Function],
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
             }
           }
           value={null}
@@ -653,8 +655,10 @@ exports[`Storyshots object-list/demo interactive table 1`] = `
           placeholder="Add Filter"
           styles={
             Object {
-              "menu": [Function],
-              "menuList": [Function],
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
             }
           }
           value={null}

--- a/src/__snapshots__/ObjectList.stories.storyshot
+++ b/src/__snapshots__/ObjectList.stories.storyshot
@@ -2323,128 +2323,17 @@ exports[`Storyshots object-list has active filters 1`] = `
             }
           />
         </div>
-        <div
-          className="css-10nd86i objectlist-current-filter__active-status"
-          id={undefined}
-          onKeyDown={[Function]}
-        >
-          <span
-            aria-atomic="true"
-            aria-live="polite"
-            className="css-1uvvha"
-            role="status"
-          >
-            0 results available.
-          </span>
-          <div
-            className="css-1aya2g8 objectlist-current-filter__active-status__control"
-            onMouseDown={[Function]}
-            onTouchEnd={[Function]}
-          >
-            <div
-              className="css-1rtrksz objectlist-current-filter__active-status__value-container objectlist-current-filter__active-status__value-container--is-multi"
-            >
-              <div
-                className="css-1492t68 objectlist-current-filter__active-status__placeholder"
-              >
-                Any value
-              </div>
-              <div
-                className="css-rsyb7x"
-              >
-                <div
-                  className="objectlist-current-filter__active-status__input"
-                  style={
-                    Object {
-                      "display": "inline-block",
-                    }
-                  }
-                >
-                  <input
-                    aria-activedescendant={undefined}
-                    aria-autocomplete="list"
-                    aria-busy={false}
-                    aria-describedby={undefined}
-                    aria-expanded={false}
-                    aria-haspopup={false}
-                    aria-label={undefined}
-                    aria-labelledby={undefined}
-                    aria-owns={undefined}
-                    autoCapitalize="none"
-                    autoComplete="off"
-                    autoCorrect="off"
-                    className={undefined}
-                    disabled={false}
-                    id="react-select-3-input"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    role="combobox"
-                    spellCheck="false"
-                    style={
-                      Object {
-                        "background": 0,
-                        "border": 0,
-                        "boxSizing": "content-box",
-                        "color": "inherit",
-                        "fontSize": "inherit",
-                        "opacity": 1,
-                        "outline": 0,
-                        "padding": 0,
-                        "width": "1px",
-                      }
-                    }
-                    tabIndex="0"
-                    type="text"
-                    value=""
-                  />
-                  <div
-                    style={
-                      Object {
-                        "height": 0,
-                        "left": 0,
-                        "overflow": "scroll",
-                        "position": "absolute",
-                        "top": 0,
-                        "visibility": "hidden",
-                        "whiteSpace": "pre",
-                      }
-                    }
-                  >
-                    
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              className="css-1wy0on6 objectlist-current-filter__active-status__indicators"
-            >
-              <span
-                className="css-d8oujb objectlist-current-filter__active-status__indicator-separator"
-                role="presentation"
-              />
-              <div
-                className="css-1ep9fjw objectlist-current-filter__active-status__indicator objectlist-current-filter__active-status__dropdown-indicator"
-                onMouseDown={[Function]}
-                onTouchEnd={[Function]}
-                role="button"
-              >
-                <svg
-                  className="css-19bqh2r"
-                  focusable="false"
-                  height={20}
-                  role="presentation"
-                  viewBox="0 0 20 20"
-                  width={20}
-                >
-                  <path
-                    d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                  />
-                </svg>
-              </div>
-            </div>
-          </div>
-        </div>
+        <Select.Async
+          className="objectlist-current-filter__active-status"
+          getOptionLabel={[Function]}
+          getOptionValue={[Function]}
+          isMulti={true}
+          loadOptions={[Function]}
+          onChange={[Function]}
+          options={Array []}
+          placeholder="Any value"
+          value={null}
+        />
         <button
           className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
           onClick={[Function]}
@@ -3764,128 +3653,17 @@ exports[`Storyshots object-list has everything 1`] = `
             }
           />
         </div>
-        <div
-          className="css-10nd86i objectlist-current-filter__active-status"
-          id={undefined}
-          onKeyDown={[Function]}
-        >
-          <span
-            aria-atomic="true"
-            aria-live="polite"
-            className="css-1uvvha"
-            role="status"
-          >
-            0 results available.
-          </span>
-          <div
-            className="css-1aya2g8 objectlist-current-filter__active-status__control"
-            onMouseDown={[Function]}
-            onTouchEnd={[Function]}
-          >
-            <div
-              className="css-1rtrksz objectlist-current-filter__active-status__value-container objectlist-current-filter__active-status__value-container--is-multi"
-            >
-              <div
-                className="css-1492t68 objectlist-current-filter__active-status__placeholder"
-              >
-                Any value
-              </div>
-              <div
-                className="css-rsyb7x"
-              >
-                <div
-                  className="objectlist-current-filter__active-status__input"
-                  style={
-                    Object {
-                      "display": "inline-block",
-                    }
-                  }
-                >
-                  <input
-                    aria-activedescendant={undefined}
-                    aria-autocomplete="list"
-                    aria-busy={false}
-                    aria-describedby={undefined}
-                    aria-expanded={false}
-                    aria-haspopup={false}
-                    aria-label={undefined}
-                    aria-labelledby={undefined}
-                    aria-owns={undefined}
-                    autoCapitalize="none"
-                    autoComplete="off"
-                    autoCorrect="off"
-                    className={undefined}
-                    disabled={false}
-                    id="react-select-2-input"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    role="combobox"
-                    spellCheck="false"
-                    style={
-                      Object {
-                        "background": 0,
-                        "border": 0,
-                        "boxSizing": "content-box",
-                        "color": "inherit",
-                        "fontSize": "inherit",
-                        "opacity": 1,
-                        "outline": 0,
-                        "padding": 0,
-                        "width": "1px",
-                      }
-                    }
-                    tabIndex="0"
-                    type="text"
-                    value=""
-                  />
-                  <div
-                    style={
-                      Object {
-                        "height": 0,
-                        "left": 0,
-                        "overflow": "scroll",
-                        "position": "absolute",
-                        "top": 0,
-                        "visibility": "hidden",
-                        "whiteSpace": "pre",
-                      }
-                    }
-                  >
-                    
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              className="css-1wy0on6 objectlist-current-filter__active-status__indicators"
-            >
-              <span
-                className="css-d8oujb objectlist-current-filter__active-status__indicator-separator"
-                role="presentation"
-              />
-              <div
-                className="css-1ep9fjw objectlist-current-filter__active-status__indicator objectlist-current-filter__active-status__dropdown-indicator"
-                onMouseDown={[Function]}
-                onTouchEnd={[Function]}
-                role="button"
-              >
-                <svg
-                  className="css-19bqh2r"
-                  focusable="false"
-                  height={20}
-                  role="presentation"
-                  viewBox="0 0 20 20"
-                  width={20}
-                >
-                  <path
-                    d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                  />
-                </svg>
-              </div>
-            </div>
-          </div>
-        </div>
+        <Select.Async
+          className="objectlist-current-filter__active-status"
+          getOptionLabel={[Function]}
+          getOptionValue={[Function]}
+          isMulti={true}
+          loadOptions={[Function]}
+          onChange={[Function]}
+          options={Array []}
+          placeholder="Any value"
+          value={null}
+        />
         <button
           className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
           onClick={[Function]}

--- a/src/__snapshots__/ObjectList.stories.storyshot
+++ b/src/__snapshots__/ObjectList.stories.storyshot
@@ -96,8 +96,10 @@ exports[`Storyshots object-list all selected 1`] = `
           placeholder="Add Filter"
           styles={
             Object {
-              "menu": [Function],
-              "menuList": [Function],
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
             }
           }
           value={null}
@@ -703,8 +705,10 @@ exports[`Storyshots object-list can select all 1`] = `
           placeholder="Add Filter"
           styles={
             Object {
-              "menu": [Function],
-              "menuList": [Function],
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
             }
           }
           value={null}
@@ -1320,8 +1324,10 @@ exports[`Storyshots object-list can select items 1`] = `
           placeholder="Add Filter"
           styles={
             Object {
-              "menu": [Function],
-              "menuList": [Function],
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
             }
           }
           value={null}
@@ -1879,8 +1885,10 @@ exports[`Storyshots object-list has active filters 1`] = `
           placeholder="Add Filter"
           styles={
             Object {
-              "menu": [Function],
-              "menuList": [Function],
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
             }
           }
           value={null}
@@ -2123,7 +2131,20 @@ exports[`Storyshots object-list has active filters 1`] = `
                 },
               ]
             }
-            value="is"
+            styles={
+              Object {
+                "control": [Function],
+                "dropdownIndicator": [Function],
+                "multiValue": [Function],
+                "multiValueLabel": [Function],
+              }
+            }
+            value={
+              Object {
+                "label": "Is",
+                "value": "is",
+              }
+            }
           />
         </div>
         <Select
@@ -2135,6 +2156,14 @@ exports[`Storyshots object-list has active filters 1`] = `
           onChange={[Function]}
           options={Array []}
           placeholder="Any value"
+          styles={
+            Object {
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
+            }
+          }
           value={null}
         />
         <button
@@ -2213,7 +2242,20 @@ exports[`Storyshots object-list has active filters 1`] = `
                 },
               ]
             }
-            value="exact"
+            styles={
+              Object {
+                "control": [Function],
+                "dropdownIndicator": [Function],
+                "multiValue": [Function],
+                "multiValueLabel": [Function],
+              }
+            }
+            value={
+              Object {
+                "label": "Exact",
+                "value": "exact",
+              }
+            }
           />
         </div>
         <div
@@ -2272,7 +2314,20 @@ exports[`Storyshots object-list has active filters 1`] = `
                 },
               ]
             }
-            value="contains"
+            styles={
+              Object {
+                "control": [Function],
+                "dropdownIndicator": [Function],
+                "multiValue": [Function],
+                "multiValueLabel": [Function],
+              }
+            }
+            value={
+              Object {
+                "label": "Contains",
+                "value": "contains",
+              }
+            }
           />
         </div>
         <input
@@ -2315,12 +2370,15 @@ exports[`Storyshots object-list has active filters 1`] = `
                 },
               ]
             }
-            value={
+            styles={
               Object {
-                "label": "Is",
-                "value": "is",
+                "control": [Function],
+                "dropdownIndicator": [Function],
+                "multiValue": [Function],
+                "multiValueLabel": [Function],
               }
             }
+            value={undefined}
           />
         </div>
         <Select.Async
@@ -2332,6 +2390,14 @@ exports[`Storyshots object-list has active filters 1`] = `
           onChange={[Function]}
           options={Array []}
           placeholder="Any value"
+          styles={
+            Object {
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
+            }
+          }
           value={null}
         />
         <button
@@ -3209,8 +3275,10 @@ exports[`Storyshots object-list has everything 1`] = `
           placeholder="Add Filter"
           styles={
             Object {
-              "menu": [Function],
-              "menuList": [Function],
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
             }
           }
           value={null}
@@ -3453,7 +3521,20 @@ exports[`Storyshots object-list has everything 1`] = `
                 },
               ]
             }
-            value="is"
+            styles={
+              Object {
+                "control": [Function],
+                "dropdownIndicator": [Function],
+                "multiValue": [Function],
+                "multiValueLabel": [Function],
+              }
+            }
+            value={
+              Object {
+                "label": "Is",
+                "value": "is",
+              }
+            }
           />
         </div>
         <Select
@@ -3465,6 +3546,14 @@ exports[`Storyshots object-list has everything 1`] = `
           onChange={[Function]}
           options={Array []}
           placeholder="Any value"
+          styles={
+            Object {
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
+            }
+          }
           value={null}
         />
         <button
@@ -3543,7 +3632,20 @@ exports[`Storyshots object-list has everything 1`] = `
                 },
               ]
             }
-            value="exact"
+            styles={
+              Object {
+                "control": [Function],
+                "dropdownIndicator": [Function],
+                "multiValue": [Function],
+                "multiValueLabel": [Function],
+              }
+            }
+            value={
+              Object {
+                "label": "Exact",
+                "value": "exact",
+              }
+            }
           />
         </div>
         <div
@@ -3602,7 +3704,20 @@ exports[`Storyshots object-list has everything 1`] = `
                 },
               ]
             }
-            value="contains"
+            styles={
+              Object {
+                "control": [Function],
+                "dropdownIndicator": [Function],
+                "multiValue": [Function],
+                "multiValueLabel": [Function],
+              }
+            }
+            value={
+              Object {
+                "label": "Contains",
+                "value": "contains",
+              }
+            }
           />
         </div>
         <input
@@ -3645,12 +3760,15 @@ exports[`Storyshots object-list has everything 1`] = `
                 },
               ]
             }
-            value={
+            styles={
               Object {
-                "label": "Is",
-                "value": "is",
+                "control": [Function],
+                "dropdownIndicator": [Function],
+                "multiValue": [Function],
+                "multiValueLabel": [Function],
               }
             }
+            value={undefined}
           />
         </div>
         <Select.Async
@@ -3662,6 +3780,14 @@ exports[`Storyshots object-list has everything 1`] = `
           onChange={[Function]}
           options={Array []}
           placeholder="Any value"
+          styles={
+            Object {
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
+            }
+          }
           value={null}
         />
         <button
@@ -4220,8 +4346,10 @@ exports[`Storyshots object-list has multiple pages 1`] = `
           placeholder="Add Filter"
           styles={
             Object {
-              "menu": [Function],
-              "menuList": [Function],
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
             }
           }
           value={null}
@@ -4686,8 +4814,10 @@ exports[`Storyshots object-list has optional fields 1`] = `
           placeholder="Add Filter"
           styles={
             Object {
-              "menu": [Function],
-              "menuList": [Function],
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
             }
           }
           value={null}
@@ -5189,8 +5319,10 @@ exports[`Storyshots object-list has search key 1`] = `
           placeholder="Add Filter"
           styles={
             Object {
-              "menu": [Function],
-              "menuList": [Function],
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
             }
           }
           value={null}
@@ -5655,8 +5787,10 @@ exports[`Storyshots object-list loading 1`] = `
           placeholder="Add Filter"
           styles={
             Object {
-              "menu": [Function],
-              "menuList": [Function],
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
             }
           }
           value={null}
@@ -6131,8 +6265,10 @@ exports[`Storyshots object-list ready 1`] = `
           placeholder="Add Filter"
           styles={
             Object {
-              "menu": [Function],
-              "menuList": [Function],
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
             }
           }
           value={null}

--- a/src/__snapshots__/ObjectList.stories.storyshot
+++ b/src/__snapshots__/ObjectList.stories.storyshot
@@ -11,19 +11,10 @@ exports[`Storyshots object-list all selected 1`] = `
       >
         <Select
           className="objectlist-select-filter"
-          labelKey="name"
-          menuContainerStyle={
-            Object {
-              "maxHeight": "500px",
-            }
-          }
-          menuStyle={
-            Object {
-              "maxHeight": "500px",
-            }
-          }
+          getOptionLabel={[Function]}
+          getOptionValue={[Function]}
           onChange={[Function]}
-          openOnFocus={true}
+          openMenuOnClick={true}
           options={
             Array [
               Object {
@@ -103,8 +94,13 @@ exports[`Storyshots object-list all selected 1`] = `
             ]
           }
           placeholder="Add Filter"
+          styles={
+            Object {
+              "menu": [Function],
+              "menuList": [Function],
+            }
+          }
           value={null}
-          valueKey="filterKey"
         />
         <div
           className="objectlist-dropdown"
@@ -622,19 +618,10 @@ exports[`Storyshots object-list can select all 1`] = `
       >
         <Select
           className="objectlist-select-filter"
-          labelKey="name"
-          menuContainerStyle={
-            Object {
-              "maxHeight": "500px",
-            }
-          }
-          menuStyle={
-            Object {
-              "maxHeight": "500px",
-            }
-          }
+          getOptionLabel={[Function]}
+          getOptionValue={[Function]}
           onChange={[Function]}
-          openOnFocus={true}
+          openMenuOnClick={true}
           options={
             Array [
               Object {
@@ -714,8 +701,13 @@ exports[`Storyshots object-list can select all 1`] = `
             ]
           }
           placeholder="Add Filter"
+          styles={
+            Object {
+              "menu": [Function],
+              "menuList": [Function],
+            }
+          }
           value={null}
-          valueKey="filterKey"
         />
         <div
           className="objectlist-dropdown"
@@ -1243,19 +1235,10 @@ exports[`Storyshots object-list can select items 1`] = `
       >
         <Select
           className="objectlist-select-filter"
-          labelKey="name"
-          menuContainerStyle={
-            Object {
-              "maxHeight": "500px",
-            }
-          }
-          menuStyle={
-            Object {
-              "maxHeight": "500px",
-            }
-          }
+          getOptionLabel={[Function]}
+          getOptionValue={[Function]}
           onChange={[Function]}
-          openOnFocus={true}
+          openMenuOnClick={true}
           options={
             Array [
               Object {
@@ -1335,8 +1318,13 @@ exports[`Storyshots object-list can select items 1`] = `
             ]
           }
           placeholder="Add Filter"
+          styles={
+            Object {
+              "menu": [Function],
+              "menuList": [Function],
+            }
+          }
           value={null}
-          valueKey="filterKey"
         />
         <div
           className="objectlist-dropdown"
@@ -1843,19 +1831,10 @@ exports[`Storyshots object-list has active filters 1`] = `
       >
         <Select
           className="objectlist-select-filter"
-          labelKey="name"
-          menuContainerStyle={
-            Object {
-              "maxHeight": "500px",
-            }
-          }
-          menuStyle={
-            Object {
-              "maxHeight": "500px",
-            }
-          }
+          getOptionLabel={[Function]}
+          getOptionValue={[Function]}
           onChange={[Function]}
-          openOnFocus={true}
+          openMenuOnClick={true}
           options={
             Array [
               Object {
@@ -1898,8 +1877,13 @@ exports[`Storyshots object-list has active filters 1`] = `
             ]
           }
           placeholder="Add Filter"
+          styles={
+            Object {
+              "menu": [Function],
+              "menuList": [Function],
+            }
+          }
           value={null}
-          valueKey="filterKey"
         />
         <div
           className="objectlist-dropdown"
@@ -2125,7 +2109,7 @@ exports[`Storyshots object-list has active filters 1`] = `
           className="objectlist-current-filter__filter-comparison"
         >
           <Select
-            clearable={false}
+            isClearable={false}
             onChange={[Function]}
             options={
               Array [
@@ -2144,15 +2128,14 @@ exports[`Storyshots object-list has active filters 1`] = `
         </div>
         <Select
           className="objectlist-current-filter__active-status"
-          labelKey="label"
+          getOptionLabel={[Function]}
+          getOptionValue={[Function]}
+          isMulti={false}
           loadOptions={undefined}
-          multi={false}
           onChange={[Function]}
-          optionRenderer={null}
           options={Array []}
           placeholder="Any value"
           value={null}
-          valueKey="value"
         />
         <button
           className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
@@ -2204,7 +2187,7 @@ exports[`Storyshots object-list has active filters 1`] = `
           className="objectlist-current-filter__filter-comparison"
         >
           <Select
-            clearable={false}
+            isClearable={false}
             onChange={[Function]}
             options={
               Array [
@@ -2275,7 +2258,7 @@ exports[`Storyshots object-list has active filters 1`] = `
           className="objectlist-current-filter__filter-comparison"
         >
           <Select
-            clearable={false}
+            isClearable={false}
             onChange={[Function]}
             options={
               Array [
@@ -2318,7 +2301,7 @@ exports[`Storyshots object-list has active filters 1`] = `
           className="objectlist-current-filter__filter-comparison"
         >
           <Select
-            clearable={false}
+            isClearable={false}
             onChange={[Function]}
             options={
               Array [
@@ -2340,18 +2323,128 @@ exports[`Storyshots object-list has active filters 1`] = `
             }
           />
         </div>
-        <Select.Async
-          className="objectlist-current-filter__active-status"
-          labelKey="label"
-          loadOptions={[Function]}
-          multi={true}
-          onChange={[Function]}
-          optionRenderer={null}
-          options={Array []}
-          placeholder="Any value"
-          value={null}
-          valueKey="value"
-        />
+        <div
+          className="css-10nd86i objectlist-current-filter__active-status"
+          id={undefined}
+          onKeyDown={[Function]}
+        >
+          <span
+            aria-atomic="true"
+            aria-live="polite"
+            className="css-1uvvha"
+            role="status"
+          >
+            0 results available.
+          </span>
+          <div
+            className="css-1aya2g8 objectlist-current-filter__active-status__control"
+            onMouseDown={[Function]}
+            onTouchEnd={[Function]}
+          >
+            <div
+              className="css-1rtrksz objectlist-current-filter__active-status__value-container objectlist-current-filter__active-status__value-container--is-multi"
+            >
+              <div
+                className="css-1492t68 objectlist-current-filter__active-status__placeholder"
+              >
+                Any value
+              </div>
+              <div
+                className="css-rsyb7x"
+              >
+                <div
+                  className="objectlist-current-filter__active-status__input"
+                  style={
+                    Object {
+                      "display": "inline-block",
+                    }
+                  }
+                >
+                  <input
+                    aria-activedescendant={undefined}
+                    aria-autocomplete="list"
+                    aria-busy={false}
+                    aria-describedby={undefined}
+                    aria-expanded={false}
+                    aria-haspopup={false}
+                    aria-label={undefined}
+                    aria-labelledby={undefined}
+                    aria-owns={undefined}
+                    autoCapitalize="none"
+                    autoComplete="off"
+                    autoCorrect="off"
+                    className={undefined}
+                    disabled={false}
+                    id="react-select-3-input"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    role="combobox"
+                    spellCheck="false"
+                    style={
+                      Object {
+                        "background": 0,
+                        "border": 0,
+                        "boxSizing": "content-box",
+                        "color": "inherit",
+                        "fontSize": "inherit",
+                        "opacity": 1,
+                        "outline": 0,
+                        "padding": 0,
+                        "width": "1px",
+                      }
+                    }
+                    tabIndex="0"
+                    type="text"
+                    value=""
+                  />
+                  <div
+                    style={
+                      Object {
+                        "height": 0,
+                        "left": 0,
+                        "overflow": "scroll",
+                        "position": "absolute",
+                        "top": 0,
+                        "visibility": "hidden",
+                        "whiteSpace": "pre",
+                      }
+                    }
+                  >
+                    
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="css-1wy0on6 objectlist-current-filter__active-status__indicators"
+            >
+              <span
+                className="css-d8oujb objectlist-current-filter__active-status__indicator-separator"
+                role="presentation"
+              />
+              <div
+                className="css-1ep9fjw objectlist-current-filter__active-status__indicator objectlist-current-filter__active-status__dropdown-indicator"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
+                role="button"
+              >
+                <svg
+                  className="css-19bqh2r"
+                  focusable="false"
+                  height={20}
+                  role="presentation"
+                  viewBox="0 0 20 20"
+                  width={20}
+                >
+                  <path
+                    d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+        </div>
         <button
           className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
           onClick={[Function]}
@@ -3185,19 +3278,10 @@ exports[`Storyshots object-list has everything 1`] = `
       >
         <Select
           className="objectlist-select-filter"
-          labelKey="name"
-          menuContainerStyle={
-            Object {
-              "maxHeight": "500px",
-            }
-          }
-          menuStyle={
-            Object {
-              "maxHeight": "500px",
-            }
-          }
+          getOptionLabel={[Function]}
+          getOptionValue={[Function]}
           onChange={[Function]}
-          openOnFocus={true}
+          openMenuOnClick={true}
           options={
             Array [
               Object {
@@ -3234,8 +3318,13 @@ exports[`Storyshots object-list has everything 1`] = `
             ]
           }
           placeholder="Add Filter"
+          styles={
+            Object {
+              "menu": [Function],
+              "menuList": [Function],
+            }
+          }
           value={null}
-          valueKey="filterKey"
         />
         <div
           className="objectlist-dropdown"
@@ -3461,7 +3550,7 @@ exports[`Storyshots object-list has everything 1`] = `
           className="objectlist-current-filter__filter-comparison"
         >
           <Select
-            clearable={false}
+            isClearable={false}
             onChange={[Function]}
             options={
               Array [
@@ -3480,15 +3569,14 @@ exports[`Storyshots object-list has everything 1`] = `
         </div>
         <Select
           className="objectlist-current-filter__active-status"
-          labelKey="label"
+          getOptionLabel={[Function]}
+          getOptionValue={[Function]}
+          isMulti={false}
           loadOptions={undefined}
-          multi={false}
           onChange={[Function]}
-          optionRenderer={null}
           options={Array []}
           placeholder="Any value"
           value={null}
-          valueKey="value"
         />
         <button
           className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
@@ -3540,7 +3628,7 @@ exports[`Storyshots object-list has everything 1`] = `
           className="objectlist-current-filter__filter-comparison"
         >
           <Select
-            clearable={false}
+            isClearable={false}
             onChange={[Function]}
             options={
               Array [
@@ -3611,7 +3699,7 @@ exports[`Storyshots object-list has everything 1`] = `
           className="objectlist-current-filter__filter-comparison"
         >
           <Select
-            clearable={false}
+            isClearable={false}
             onChange={[Function]}
             options={
               Array [
@@ -3654,7 +3742,7 @@ exports[`Storyshots object-list has everything 1`] = `
           className="objectlist-current-filter__filter-comparison"
         >
           <Select
-            clearable={false}
+            isClearable={false}
             onChange={[Function]}
             options={
               Array [
@@ -3676,18 +3764,128 @@ exports[`Storyshots object-list has everything 1`] = `
             }
           />
         </div>
-        <Select.Async
-          className="objectlist-current-filter__active-status"
-          labelKey="label"
-          loadOptions={[Function]}
-          multi={true}
-          onChange={[Function]}
-          optionRenderer={null}
-          options={Array []}
-          placeholder="Any value"
-          value={null}
-          valueKey="value"
-        />
+        <div
+          className="css-10nd86i objectlist-current-filter__active-status"
+          id={undefined}
+          onKeyDown={[Function]}
+        >
+          <span
+            aria-atomic="true"
+            aria-live="polite"
+            className="css-1uvvha"
+            role="status"
+          >
+            0 results available.
+          </span>
+          <div
+            className="css-1aya2g8 objectlist-current-filter__active-status__control"
+            onMouseDown={[Function]}
+            onTouchEnd={[Function]}
+          >
+            <div
+              className="css-1rtrksz objectlist-current-filter__active-status__value-container objectlist-current-filter__active-status__value-container--is-multi"
+            >
+              <div
+                className="css-1492t68 objectlist-current-filter__active-status__placeholder"
+              >
+                Any value
+              </div>
+              <div
+                className="css-rsyb7x"
+              >
+                <div
+                  className="objectlist-current-filter__active-status__input"
+                  style={
+                    Object {
+                      "display": "inline-block",
+                    }
+                  }
+                >
+                  <input
+                    aria-activedescendant={undefined}
+                    aria-autocomplete="list"
+                    aria-busy={false}
+                    aria-describedby={undefined}
+                    aria-expanded={false}
+                    aria-haspopup={false}
+                    aria-label={undefined}
+                    aria-labelledby={undefined}
+                    aria-owns={undefined}
+                    autoCapitalize="none"
+                    autoComplete="off"
+                    autoCorrect="off"
+                    className={undefined}
+                    disabled={false}
+                    id="react-select-2-input"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    role="combobox"
+                    spellCheck="false"
+                    style={
+                      Object {
+                        "background": 0,
+                        "border": 0,
+                        "boxSizing": "content-box",
+                        "color": "inherit",
+                        "fontSize": "inherit",
+                        "opacity": 1,
+                        "outline": 0,
+                        "padding": 0,
+                        "width": "1px",
+                      }
+                    }
+                    tabIndex="0"
+                    type="text"
+                    value=""
+                  />
+                  <div
+                    style={
+                      Object {
+                        "height": 0,
+                        "left": 0,
+                        "overflow": "scroll",
+                        "position": "absolute",
+                        "top": 0,
+                        "visibility": "hidden",
+                        "whiteSpace": "pre",
+                      }
+                    }
+                  >
+                    
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="css-1wy0on6 objectlist-current-filter__active-status__indicators"
+            >
+              <span
+                className="css-d8oujb objectlist-current-filter__active-status__indicator-separator"
+                role="presentation"
+              />
+              <div
+                className="css-1ep9fjw objectlist-current-filter__active-status__indicator objectlist-current-filter__active-status__dropdown-indicator"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
+                role="button"
+              >
+                <svg
+                  className="css-19bqh2r"
+                  focusable="false"
+                  height={20}
+                  role="presentation"
+                  viewBox="0 0 20 20"
+                  width={20}
+                >
+                  <path
+                    d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+        </div>
         <button
           className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
           onClick={[Function]}
@@ -4159,19 +4357,10 @@ exports[`Storyshots object-list has multiple pages 1`] = `
       >
         <Select
           className="objectlist-select-filter"
-          labelKey="name"
-          menuContainerStyle={
-            Object {
-              "maxHeight": "500px",
-            }
-          }
-          menuStyle={
-            Object {
-              "maxHeight": "500px",
-            }
-          }
+          getOptionLabel={[Function]}
+          getOptionValue={[Function]}
           onChange={[Function]}
-          openOnFocus={true}
+          openMenuOnClick={true}
           options={
             Array [
               Object {
@@ -4251,8 +4440,13 @@ exports[`Storyshots object-list has multiple pages 1`] = `
             ]
           }
           placeholder="Add Filter"
+          styles={
+            Object {
+              "menu": [Function],
+              "menuList": [Function],
+            }
+          }
           value={null}
-          valueKey="filterKey"
         />
         <div
           className="objectlist-dropdown"
@@ -4629,19 +4823,10 @@ exports[`Storyshots object-list has optional fields 1`] = `
       >
         <Select
           className="objectlist-select-filter"
-          labelKey="name"
-          menuContainerStyle={
-            Object {
-              "maxHeight": "500px",
-            }
-          }
-          menuStyle={
-            Object {
-              "maxHeight": "500px",
-            }
-          }
+          getOptionLabel={[Function]}
+          getOptionValue={[Function]}
           onChange={[Function]}
-          openOnFocus={true}
+          openMenuOnClick={true}
           options={
             Array [
               Object {
@@ -4721,8 +4906,13 @@ exports[`Storyshots object-list has optional fields 1`] = `
             ]
           }
           placeholder="Add Filter"
+          styles={
+            Object {
+              "menu": [Function],
+              "menuList": [Function],
+            }
+          }
           value={null}
-          valueKey="filterKey"
         />
         <div
           className="objectlist-dropdown"
@@ -5142,19 +5332,10 @@ exports[`Storyshots object-list has search key 1`] = `
       >
         <Select
           className="objectlist-select-filter"
-          labelKey="name"
-          menuContainerStyle={
-            Object {
-              "maxHeight": "500px",
-            }
-          }
-          menuStyle={
-            Object {
-              "maxHeight": "500px",
-            }
-          }
+          getOptionLabel={[Function]}
+          getOptionValue={[Function]}
           onChange={[Function]}
-          openOnFocus={true}
+          openMenuOnClick={true}
           options={
             Array [
               Object {
@@ -5228,8 +5409,13 @@ exports[`Storyshots object-list has search key 1`] = `
             ]
           }
           placeholder="Add Filter"
+          styles={
+            Object {
+              "menu": [Function],
+              "menuList": [Function],
+            }
+          }
           value={null}
-          valueKey="filterKey"
         />
         <div
           className="objectlist-dropdown"
@@ -5606,19 +5792,10 @@ exports[`Storyshots object-list loading 1`] = `
       >
         <Select
           className="objectlist-select-filter"
-          labelKey="name"
-          menuContainerStyle={
-            Object {
-              "maxHeight": "500px",
-            }
-          }
-          menuStyle={
-            Object {
-              "maxHeight": "500px",
-            }
-          }
+          getOptionLabel={[Function]}
+          getOptionValue={[Function]}
           onChange={[Function]}
-          openOnFocus={true}
+          openMenuOnClick={true}
           options={
             Array [
               Object {
@@ -5698,8 +5875,13 @@ exports[`Storyshots object-list loading 1`] = `
             ]
           }
           placeholder="Add Filter"
+          styles={
+            Object {
+              "menu": [Function],
+              "menuList": [Function],
+            }
+          }
           value={null}
-          valueKey="filterKey"
         />
         <div
           className="objectlist-dropdown"
@@ -6086,19 +6268,10 @@ exports[`Storyshots object-list ready 1`] = `
       >
         <Select
           className="objectlist-select-filter"
-          labelKey="name"
-          menuContainerStyle={
-            Object {
-              "maxHeight": "500px",
-            }
-          }
-          menuStyle={
-            Object {
-              "maxHeight": "500px",
-            }
-          }
+          getOptionLabel={[Function]}
+          getOptionValue={[Function]}
           onChange={[Function]}
-          openOnFocus={true}
+          openMenuOnClick={true}
           options={
             Array [
               Object {
@@ -6178,8 +6351,13 @@ exports[`Storyshots object-list ready 1`] = `
             ]
           }
           placeholder="Add Filter"
+          styles={
+            Object {
+              "menu": [Function],
+              "menuList": [Function],
+            }
+          }
           value={null}
-          valueKey="filterKey"
         />
         <div
           className="objectlist-dropdown"

--- a/src/actions-filters/SelectFilters.js
+++ b/src/actions-filters/SelectFilters.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import Select from 'react-select'
+import Select from '../utils/Select'
 import {FILTER_BASE_TYPE} from '../utils/proptypes'
 import { sortByName } from '../utils'
 

--- a/src/actions-filters/SelectFilters.js
+++ b/src/actions-filters/SelectFilters.js
@@ -1,8 +1,8 @@
-import React, { Component } from 'react'
+import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import Select from '../utils/Select'
 import {FILTER_BASE_TYPE} from '../utils/proptypes'
-import { sortByName } from '../utils'
+import {sortByName} from '../utils'
 
 class SelectFilters extends Component {
   static propTypes = {
@@ -20,10 +20,16 @@ class SelectFilters extends Component {
   render() {
     if (this.props.filters.length === 0) { return null }
 
-    let quickFilters = this.props.filters.filter((filter) => {
-      return (!(filter.active) && !filter.alwaysVisible)
-    })
+    let quickFilters = this.props.filters.filter(filter =>
+      !filter.active && !filter.alwaysVisible
+    )
     quickFilters = quickFilters.sort(sortByName)
+
+    // There's something pretty odd happening with react-select v2 that
+    // causes any option that itself contains an `options` field to use
+    // that subfield instead of itself. WTF.
+    // TODO: Check if this issue has been resolved in a later version.
+    quickFilters = quickFilters.map(({options, ...rest}) => rest)
 
     return (
       <Select
@@ -35,8 +41,6 @@ class SelectFilters extends Component {
         onChange={this.props.addFilter}
         placeholder="Add Filter"
         className="objectlist-select-filter"
-        menuStyle={{maxHeight: '500px'}}
-        menuContainerStyle={{maxHeight: '500px'}}
       />
     )
   }

--- a/src/actions-filters/__snapshots__/ActionsFiltersContainer.stories.storyshot
+++ b/src/actions-filters/__snapshots__/ActionsFiltersContainer.stories.storyshot
@@ -18,8 +18,10 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
         placeholder="Add Filter"
         styles={
           Object {
-            "menu": [Function],
-            "menuList": [Function],
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
           }
         }
         value={null}
@@ -96,6 +98,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
           ]
         }
         placeholder="Any value"
+        styles={
+          Object {
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
+          }
+        }
         value={null}
       />
       <button
@@ -311,12 +321,15 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
               },
             ]
           }
-          value={
+          styles={
             Object {
-              "label": "Exact",
-              "value": "exact",
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
             }
           }
+          value={undefined}
         />
       </div>
       <div
@@ -372,7 +385,20 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
               },
             ]
           }
-          value="is"
+          styles={
+            Object {
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
+            }
+          }
+          value={
+            Object {
+              "label": "Is",
+              "value": "is",
+            }
+          }
         />
       </div>
       <Select
@@ -384,6 +410,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
         onChange={[Function]}
         options={Array []}
         placeholder="Any value"
+        styles={
+          Object {
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
+          }
+        }
         value={null}
       />
       <button
@@ -419,7 +453,20 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
               },
             ]
           }
-          value="relative"
+          styles={
+            Object {
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
+            }
+          }
+          value={
+            Object {
+              "label": "Relative to Now",
+              "value": "relative",
+            }
+          }
         />
       </div>
       <Select
@@ -445,6 +492,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
               "value": "year_start",
             },
           ]
+        }
+        styles={
+          Object {
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
+          }
         }
       />
       <button
@@ -511,7 +566,20 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
               },
             ]
           }
-          value="is"
+          styles={
+            Object {
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
+            }
+          }
+          value={
+            Object {
+              "label": "Is",
+              "value": "is",
+            }
+          }
         />
       </div>
       <Select
@@ -523,6 +591,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
         onChange={[Function]}
         options={Array []}
         placeholder="Any value"
+        styles={
+          Object {
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
+          }
+        }
         value={null}
       />
       <button
@@ -570,7 +646,20 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
               },
             ]
           }
-          value="exact"
+          styles={
+            Object {
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
+            }
+          }
+          value={
+            Object {
+              "label": "Exact",
+              "value": "exact",
+            }
+          }
         />
       </div>
       <div
@@ -646,7 +735,20 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
               },
             ]
           }
-          value="contains"
+          styles={
+            Object {
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
+            }
+          }
+          value={
+            Object {
+              "label": "Contains",
+              "value": "contains",
+            }
+          }
         />
       </div>
       <input
@@ -680,6 +782,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
         onChange={[Function]}
         options={Array []}
         placeholder="Any value"
+        styles={
+          Object {
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
+          }
+        }
         value={null}
       />
       <button
@@ -715,12 +825,15 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
               },
             ]
           }
-          value={
+          styles={
             Object {
-              "label": "Is",
-              "value": "is",
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
             }
           }
+          value={undefined}
         />
       </div>
       <Select.Async
@@ -732,6 +845,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
         onChange={[Function]}
         options={Array []}
         placeholder="Any value"
+        styles={
+          Object {
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
+          }
+        }
         value={null}
       />
       <button
@@ -914,8 +1035,10 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
         placeholder="Add Filter"
         styles={
           Object {
-            "menu": [Function],
-            "menuList": [Function],
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
           }
         }
         value={null}
@@ -992,6 +1115,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
           ]
         }
         placeholder="Any value"
+        styles={
+          Object {
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
+          }
+        }
         value={null}
       />
       <button
@@ -1207,12 +1338,15 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
               },
             ]
           }
-          value={
+          styles={
             Object {
-              "label": "Exact",
-              "value": "exact",
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
             }
           }
+          value={undefined}
         />
       </div>
       <div
@@ -1268,7 +1402,20 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
               },
             ]
           }
-          value="is"
+          styles={
+            Object {
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
+            }
+          }
+          value={
+            Object {
+              "label": "Is",
+              "value": "is",
+            }
+          }
         />
       </div>
       <Select
@@ -1280,6 +1427,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
         onChange={[Function]}
         options={Array []}
         placeholder="Any value"
+        styles={
+          Object {
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
+          }
+        }
         value={null}
       />
       <button
@@ -1315,7 +1470,20 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
               },
             ]
           }
-          value="relative"
+          styles={
+            Object {
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
+            }
+          }
+          value={
+            Object {
+              "label": "Relative to Now",
+              "value": "relative",
+            }
+          }
         />
       </div>
       <Select
@@ -1341,6 +1509,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
               "value": "year_start",
             },
           ]
+        }
+        styles={
+          Object {
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
+          }
         }
       />
       <button
@@ -1407,7 +1583,20 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
               },
             ]
           }
-          value="is"
+          styles={
+            Object {
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
+            }
+          }
+          value={
+            Object {
+              "label": "Is",
+              "value": "is",
+            }
+          }
         />
       </div>
       <Select
@@ -1419,6 +1608,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
         onChange={[Function]}
         options={Array []}
         placeholder="Any value"
+        styles={
+          Object {
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
+          }
+        }
         value={null}
       />
       <button
@@ -1466,7 +1663,20 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
               },
             ]
           }
-          value="exact"
+          styles={
+            Object {
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
+            }
+          }
+          value={
+            Object {
+              "label": "Exact",
+              "value": "exact",
+            }
+          }
         />
       </div>
       <div
@@ -1542,7 +1752,20 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
               },
             ]
           }
-          value="contains"
+          styles={
+            Object {
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
+            }
+          }
+          value={
+            Object {
+              "label": "Contains",
+              "value": "contains",
+            }
+          }
         />
       </div>
       <input
@@ -1576,6 +1799,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
         onChange={[Function]}
         options={Array []}
         placeholder="Any value"
+        styles={
+          Object {
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
+          }
+        }
         value={null}
       />
       <button
@@ -1611,12 +1842,15 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
               },
             ]
           }
-          value={
+          styles={
             Object {
-              "label": "Is",
-              "value": "is",
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
             }
           }
+          value={undefined}
         />
       </div>
       <Select.Async
@@ -1628,6 +1862,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
         onChange={[Function]}
         options={Array []}
         placeholder="Any value"
+        styles={
+          Object {
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
+          }
+        }
         value={null}
       />
       <button
@@ -1722,8 +1964,10 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
         placeholder="Add Filter"
         styles={
           Object {
-            "menu": [Function],
-            "menuList": [Function],
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
           }
         }
         value={null}
@@ -1800,6 +2044,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
           ]
         }
         placeholder="Any value"
+        styles={
+          Object {
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
+          }
+        }
         value={null}
       />
       <button
@@ -2015,12 +2267,15 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
               },
             ]
           }
-          value={
+          styles={
             Object {
-              "label": "Exact",
-              "value": "exact",
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
             }
           }
+          value={undefined}
         />
       </div>
       <div
@@ -2076,7 +2331,20 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
               },
             ]
           }
-          value="is"
+          styles={
+            Object {
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
+            }
+          }
+          value={
+            Object {
+              "label": "Is",
+              "value": "is",
+            }
+          }
         />
       </div>
       <Select
@@ -2088,6 +2356,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
         onChange={[Function]}
         options={Array []}
         placeholder="Any value"
+        styles={
+          Object {
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
+          }
+        }
         value={null}
       />
       <button
@@ -2123,7 +2399,20 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
               },
             ]
           }
-          value="relative"
+          styles={
+            Object {
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
+            }
+          }
+          value={
+            Object {
+              "label": "Relative to Now",
+              "value": "relative",
+            }
+          }
         />
       </div>
       <Select
@@ -2149,6 +2438,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
               "value": "year_start",
             },
           ]
+        }
+        styles={
+          Object {
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
+          }
         }
       />
       <button
@@ -2215,7 +2512,20 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
               },
             ]
           }
-          value="is"
+          styles={
+            Object {
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
+            }
+          }
+          value={
+            Object {
+              "label": "Is",
+              "value": "is",
+            }
+          }
         />
       </div>
       <Select
@@ -2227,6 +2537,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
         onChange={[Function]}
         options={Array []}
         placeholder="Any value"
+        styles={
+          Object {
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
+          }
+        }
         value={null}
       />
       <button
@@ -2274,7 +2592,20 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
               },
             ]
           }
-          value="exact"
+          styles={
+            Object {
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
+            }
+          }
+          value={
+            Object {
+              "label": "Exact",
+              "value": "exact",
+            }
+          }
         />
       </div>
       <div
@@ -2333,7 +2664,20 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
               },
             ]
           }
-          value="contains"
+          styles={
+            Object {
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
+            }
+          }
+          value={
+            Object {
+              "label": "Contains",
+              "value": "contains",
+            }
+          }
         />
       </div>
       <input
@@ -2367,6 +2711,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
         onChange={[Function]}
         options={Array []}
         placeholder="Any value"
+        styles={
+          Object {
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
+          }
+        }
         value={null}
       />
       <button
@@ -2402,12 +2754,15 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
               },
             ]
           }
-          value={
+          styles={
             Object {
-              "label": "Is",
-              "value": "is",
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
             }
           }
+          value={undefined}
         />
       </div>
       <Select.Async
@@ -2419,6 +2774,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
         onChange={[Function]}
         options={Array []}
         placeholder="Any value"
+        styles={
+          Object {
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
+          }
+        }
         value={null}
       />
       <button
@@ -2497,8 +2860,10 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
         placeholder="Add Filter"
         styles={
           Object {
-            "menu": [Function],
-            "menuList": [Function],
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
           }
         }
         value={null}
@@ -2575,6 +2940,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
           ]
         }
         placeholder="Any value"
+        styles={
+          Object {
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
+          }
+        }
         value={null}
       />
       <button
@@ -2790,12 +3163,15 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
               },
             ]
           }
-          value={
+          styles={
             Object {
-              "label": "Exact",
-              "value": "exact",
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
             }
           }
+          value={undefined}
         />
       </div>
       <div
@@ -2851,7 +3227,20 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
               },
             ]
           }
-          value="is"
+          styles={
+            Object {
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
+            }
+          }
+          value={
+            Object {
+              "label": "Is",
+              "value": "is",
+            }
+          }
         />
       </div>
       <Select
@@ -2863,6 +3252,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
         onChange={[Function]}
         options={Array []}
         placeholder="Any value"
+        styles={
+          Object {
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
+          }
+        }
         value={null}
       />
       <button
@@ -2898,7 +3295,20 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
               },
             ]
           }
-          value="relative"
+          styles={
+            Object {
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
+            }
+          }
+          value={
+            Object {
+              "label": "Relative to Now",
+              "value": "relative",
+            }
+          }
         />
       </div>
       <Select
@@ -2924,6 +3334,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
               "value": "year_start",
             },
           ]
+        }
+        styles={
+          Object {
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
+          }
         }
       />
       <button
@@ -2990,7 +3408,20 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
               },
             ]
           }
-          value="is"
+          styles={
+            Object {
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
+            }
+          }
+          value={
+            Object {
+              "label": "Is",
+              "value": "is",
+            }
+          }
         />
       </div>
       <Select
@@ -3002,6 +3433,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
         onChange={[Function]}
         options={Array []}
         placeholder="Any value"
+        styles={
+          Object {
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
+          }
+        }
         value={null}
       />
       <button
@@ -3049,7 +3488,20 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
               },
             ]
           }
-          value="exact"
+          styles={
+            Object {
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
+            }
+          }
+          value={
+            Object {
+              "label": "Exact",
+              "value": "exact",
+            }
+          }
         />
       </div>
       <div
@@ -3108,7 +3560,20 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
               },
             ]
           }
-          value="contains"
+          styles={
+            Object {
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
+            }
+          }
+          value={
+            Object {
+              "label": "Contains",
+              "value": "contains",
+            }
+          }
         />
       </div>
       <input
@@ -3142,6 +3607,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
         onChange={[Function]}
         options={Array []}
         placeholder="Any value"
+        styles={
+          Object {
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
+          }
+        }
         value={null}
       />
       <button
@@ -3177,12 +3650,15 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
               },
             ]
           }
-          value={
+          styles={
             Object {
-              "label": "Is",
-              "value": "is",
+              "control": [Function],
+              "dropdownIndicator": [Function],
+              "multiValue": [Function],
+              "multiValueLabel": [Function],
             }
           }
+          value={undefined}
         />
       </div>
       <Select.Async
@@ -3194,6 +3670,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
         onChange={[Function]}
         options={Array []}
         placeholder="Any value"
+        styles={
+          Object {
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
+          }
+        }
         value={null}
       />
       <button

--- a/src/actions-filters/__snapshots__/ActionsFiltersContainer.stories.storyshot
+++ b/src/actions-filters/__snapshots__/ActionsFiltersContainer.stories.storyshot
@@ -10,23 +10,19 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
     >
       <Select
         className="objectlist-select-filter"
-        labelKey="name"
-        menuContainerStyle={
-          Object {
-            "maxHeight": "500px",
-          }
-        }
-        menuStyle={
-          Object {
-            "maxHeight": "500px",
-          }
-        }
+        getOptionLabel={[Function]}
+        getOptionValue={[Function]}
         onChange={undefined}
-        openOnFocus={true}
+        openMenuOnClick={true}
         options={Array []}
         placeholder="Add Filter"
+        styles={
+          Object {
+            "menu": [Function],
+            "menuList": [Function],
+          }
+        }
         value={null}
-        valueKey="filterKey"
       />
       <div
         className="objectlist-dropdown"
@@ -82,11 +78,11 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
       </label>
       <Select
         className="objectlist-current-filter__active-status"
-        labelKey="label"
+        getOptionLabel={[Function]}
+        getOptionValue={[Function]}
+        isMulti={false}
         loadOptions={undefined}
-        multi={false}
         onChange={[Function]}
-        optionRenderer={null}
         options={
           Array [
             Object {
@@ -101,7 +97,6 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
         }
         placeholder="Any value"
         value={null}
-        valueKey="value"
       />
       <button
         className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
@@ -290,7 +285,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
         className="objectlist-current-filter__filter-comparison"
       >
         <Select
-          clearable={false}
+          isClearable={false}
           onChange={[Function]}
           options={
             Array [
@@ -363,7 +358,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
         className="objectlist-current-filter__filter-comparison"
       >
         <Select
-          clearable={false}
+          isClearable={false}
           onChange={[Function]}
           options={
             Array [
@@ -382,15 +377,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
       </div>
       <Select
         className="objectlist-current-filter__active-status"
-        labelKey="label"
+        getOptionLabel={[Function]}
+        getOptionValue={[Function]}
+        isMulti={false}
         loadOptions={undefined}
-        multi={false}
         onChange={[Function]}
-        optionRenderer={null}
         options={Array []}
         placeholder="Any value"
         value={null}
-        valueKey="value"
       />
       <button
         className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
@@ -411,7 +405,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
         className="objectlist-current-filter__filter-comparison"
       >
         <Select
-          clearable={false}
+          isClearable={false}
           onChange={[Function]}
           options={
             Array [
@@ -430,7 +424,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
       </div>
       <Select
         className="objectlist-current-filter__active-status"
-        clearable={false}
+        isClearable={false}
         onChange={[Function]}
         options={
           Array [
@@ -503,7 +497,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
         className="objectlist-current-filter__filter-comparison"
       >
         <Select
-          clearable={false}
+          isClearable={false}
           onChange={[Function]}
           options={
             Array [
@@ -522,15 +516,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
       </div>
       <Select
         className="objectlist-current-filter__active-status"
-        labelKey="label"
+        getOptionLabel={[Function]}
+        getOptionValue={[Function]}
+        isMulti={true}
         loadOptions={undefined}
-        multi={true}
         onChange={[Function]}
-        optionRenderer={null}
         options={Array []}
         placeholder="Any value"
         value={null}
-        valueKey="value"
       />
       <button
         className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
@@ -551,7 +544,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
         className="objectlist-current-filter__filter-comparison"
       >
         <Select
-          clearable={false}
+          isClearable={false}
           onChange={[Function]}
           options={
             Array [
@@ -639,7 +632,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
         className="objectlist-current-filter__filter-comparison"
       >
         <Select
-          clearable={false}
+          isClearable={false}
           onChange={[Function]}
           options={
             Array [
@@ -678,18 +671,128 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
         RemoteChoiceFilter
         :
       </label>
-      <Select.Async
-        className="objectlist-current-filter__active-status"
-        labelKey="label"
-        loadOptions={[Function]}
-        multi={false}
-        onChange={[Function]}
-        optionRenderer={null}
-        options={Array []}
-        placeholder="Any value"
-        value={null}
-        valueKey="value"
-      />
+      <div
+        className="css-10nd86i objectlist-current-filter__active-status"
+        id={undefined}
+        onKeyDown={[Function]}
+      >
+        <span
+          aria-atomic="true"
+          aria-live="polite"
+          className="css-1uvvha"
+          role="status"
+        >
+          0 results available.
+        </span>
+        <div
+          className="css-1aya2g8 objectlist-current-filter__active-status__control"
+          onMouseDown={[Function]}
+          onTouchEnd={[Function]}
+        >
+          <div
+            className="css-1rtrksz objectlist-current-filter__active-status__value-container"
+          >
+            <div
+              className="css-1492t68 objectlist-current-filter__active-status__placeholder"
+            >
+              Any value
+            </div>
+            <div
+              className="css-rsyb7x"
+            >
+              <div
+                className="objectlist-current-filter__active-status__input"
+                style={
+                  Object {
+                    "display": "inline-block",
+                  }
+                }
+              >
+                <input
+                  aria-activedescendant={undefined}
+                  aria-autocomplete="list"
+                  aria-busy={false}
+                  aria-describedby={undefined}
+                  aria-expanded={false}
+                  aria-haspopup={false}
+                  aria-label={undefined}
+                  aria-labelledby={undefined}
+                  aria-owns={undefined}
+                  autoCapitalize="none"
+                  autoComplete="off"
+                  autoCorrect="off"
+                  className={undefined}
+                  disabled={false}
+                  id="react-select-4-input"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  role="combobox"
+                  spellCheck="false"
+                  style={
+                    Object {
+                      "background": 0,
+                      "border": 0,
+                      "boxSizing": "content-box",
+                      "color": "inherit",
+                      "fontSize": "inherit",
+                      "opacity": 1,
+                      "outline": 0,
+                      "padding": 0,
+                      "width": "1px",
+                    }
+                  }
+                  tabIndex="0"
+                  type="text"
+                  value=""
+                />
+                <div
+                  style={
+                    Object {
+                      "height": 0,
+                      "left": 0,
+                      "overflow": "scroll",
+                      "position": "absolute",
+                      "top": 0,
+                      "visibility": "hidden",
+                      "whiteSpace": "pre",
+                    }
+                  }
+                >
+                  
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="css-1wy0on6 objectlist-current-filter__active-status__indicators"
+          >
+            <span
+              className="css-d8oujb objectlist-current-filter__active-status__indicator-separator"
+              role="presentation"
+            />
+            <div
+              className="css-1ep9fjw objectlist-current-filter__active-status__indicator objectlist-current-filter__active-status__dropdown-indicator"
+              onMouseDown={[Function]}
+              onTouchEnd={[Function]}
+              role="button"
+            >
+              <svg
+                className="css-19bqh2r"
+                focusable="false"
+                height={20}
+                role="presentation"
+                viewBox="0 0 20 20"
+                width={20}
+              >
+                <path
+                  d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
       <button
         className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
         onClick={[Function]}
@@ -709,7 +812,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
         className="objectlist-current-filter__filter-comparison"
       >
         <Select
-          clearable={false}
+          isClearable={false}
           onChange={[Function]}
           options={
             Array [
@@ -731,18 +834,128 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
           }
         />
       </div>
-      <Select.Async
-        className="objectlist-current-filter__active-status"
-        labelKey="label"
-        loadOptions={[Function]}
-        multi={true}
-        onChange={[Function]}
-        optionRenderer={null}
-        options={Array []}
-        placeholder="Any value"
-        value={null}
-        valueKey="value"
-      />
+      <div
+        className="css-10nd86i objectlist-current-filter__active-status"
+        id={undefined}
+        onKeyDown={[Function]}
+      >
+        <span
+          aria-atomic="true"
+          aria-live="polite"
+          className="css-1uvvha"
+          role="status"
+        >
+          0 results available.
+        </span>
+        <div
+          className="css-1aya2g8 objectlist-current-filter__active-status__control"
+          onMouseDown={[Function]}
+          onTouchEnd={[Function]}
+        >
+          <div
+            className="css-1rtrksz objectlist-current-filter__active-status__value-container objectlist-current-filter__active-status__value-container--is-multi"
+          >
+            <div
+              className="css-1492t68 objectlist-current-filter__active-status__placeholder"
+            >
+              Any value
+            </div>
+            <div
+              className="css-rsyb7x"
+            >
+              <div
+                className="objectlist-current-filter__active-status__input"
+                style={
+                  Object {
+                    "display": "inline-block",
+                  }
+                }
+              >
+                <input
+                  aria-activedescendant={undefined}
+                  aria-autocomplete="list"
+                  aria-busy={false}
+                  aria-describedby={undefined}
+                  aria-expanded={false}
+                  aria-haspopup={false}
+                  aria-label={undefined}
+                  aria-labelledby={undefined}
+                  aria-owns={undefined}
+                  autoCapitalize="none"
+                  autoComplete="off"
+                  autoCorrect="off"
+                  className={undefined}
+                  disabled={false}
+                  id="react-select-5-input"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  role="combobox"
+                  spellCheck="false"
+                  style={
+                    Object {
+                      "background": 0,
+                      "border": 0,
+                      "boxSizing": "content-box",
+                      "color": "inherit",
+                      "fontSize": "inherit",
+                      "opacity": 1,
+                      "outline": 0,
+                      "padding": 0,
+                      "width": "1px",
+                    }
+                  }
+                  tabIndex="0"
+                  type="text"
+                  value=""
+                />
+                <div
+                  style={
+                    Object {
+                      "height": 0,
+                      "left": 0,
+                      "overflow": "scroll",
+                      "position": "absolute",
+                      "top": 0,
+                      "visibility": "hidden",
+                      "whiteSpace": "pre",
+                    }
+                  }
+                >
+                  
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="css-1wy0on6 objectlist-current-filter__active-status__indicators"
+          >
+            <span
+              className="css-d8oujb objectlist-current-filter__active-status__indicator-separator"
+              role="presentation"
+            />
+            <div
+              className="css-1ep9fjw objectlist-current-filter__active-status__indicator objectlist-current-filter__active-status__dropdown-indicator"
+              onMouseDown={[Function]}
+              onTouchEnd={[Function]}
+              role="button"
+            >
+              <svg
+                className="css-19bqh2r"
+                focusable="false"
+                height={20}
+                role="presentation"
+                viewBox="0 0 20 20"
+                width={20}
+              >
+                <path
+                  d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
       <button
         className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
         onClick={[Function]}
@@ -915,23 +1128,19 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
     >
       <Select
         className="objectlist-select-filter"
-        labelKey="name"
-        menuContainerStyle={
-          Object {
-            "maxHeight": "500px",
-          }
-        }
-        menuStyle={
-          Object {
-            "maxHeight": "500px",
-          }
-        }
+        getOptionLabel={[Function]}
+        getOptionValue={[Function]}
         onChange={undefined}
-        openOnFocus={true}
+        openMenuOnClick={true}
         options={Array []}
         placeholder="Add Filter"
+        styles={
+          Object {
+            "menu": [Function],
+            "menuList": [Function],
+          }
+        }
         value={null}
-        valueKey="filterKey"
       />
       <div
         className="objectlist-dropdown"
@@ -987,11 +1196,11 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
       </label>
       <Select
         className="objectlist-current-filter__active-status"
-        labelKey="label"
+        getOptionLabel={[Function]}
+        getOptionValue={[Function]}
+        isMulti={false}
         loadOptions={undefined}
-        multi={false}
         onChange={[Function]}
-        optionRenderer={null}
         options={
           Array [
             Object {
@@ -1006,7 +1215,6 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
         }
         placeholder="Any value"
         value={null}
-        valueKey="value"
       />
       <button
         className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
@@ -1195,7 +1403,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
         className="objectlist-current-filter__filter-comparison"
       >
         <Select
-          clearable={false}
+          isClearable={false}
           onChange={[Function]}
           options={
             Array [
@@ -1268,7 +1476,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
         className="objectlist-current-filter__filter-comparison"
       >
         <Select
-          clearable={false}
+          isClearable={false}
           onChange={[Function]}
           options={
             Array [
@@ -1287,15 +1495,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
       </div>
       <Select
         className="objectlist-current-filter__active-status"
-        labelKey="label"
+        getOptionLabel={[Function]}
+        getOptionValue={[Function]}
+        isMulti={false}
         loadOptions={undefined}
-        multi={false}
         onChange={[Function]}
-        optionRenderer={null}
         options={Array []}
         placeholder="Any value"
         value={null}
-        valueKey="value"
       />
       <button
         className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
@@ -1316,7 +1523,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
         className="objectlist-current-filter__filter-comparison"
       >
         <Select
-          clearable={false}
+          isClearable={false}
           onChange={[Function]}
           options={
             Array [
@@ -1335,7 +1542,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
       </div>
       <Select
         className="objectlist-current-filter__active-status"
-        clearable={false}
+        isClearable={false}
         onChange={[Function]}
         options={
           Array [
@@ -1408,7 +1615,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
         className="objectlist-current-filter__filter-comparison"
       >
         <Select
-          clearable={false}
+          isClearable={false}
           onChange={[Function]}
           options={
             Array [
@@ -1427,15 +1634,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
       </div>
       <Select
         className="objectlist-current-filter__active-status"
-        labelKey="label"
+        getOptionLabel={[Function]}
+        getOptionValue={[Function]}
+        isMulti={true}
         loadOptions={undefined}
-        multi={true}
         onChange={[Function]}
-        optionRenderer={null}
         options={Array []}
         placeholder="Any value"
         value={null}
-        valueKey="value"
       />
       <button
         className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
@@ -1456,7 +1662,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
         className="objectlist-current-filter__filter-comparison"
       >
         <Select
-          clearable={false}
+          isClearable={false}
           onChange={[Function]}
           options={
             Array [
@@ -1544,7 +1750,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
         className="objectlist-current-filter__filter-comparison"
       >
         <Select
-          clearable={false}
+          isClearable={false}
           onChange={[Function]}
           options={
             Array [
@@ -1583,18 +1789,128 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
         RemoteChoiceFilter
         :
       </label>
-      <Select.Async
-        className="objectlist-current-filter__active-status"
-        labelKey="label"
-        loadOptions={[Function]}
-        multi={false}
-        onChange={[Function]}
-        optionRenderer={null}
-        options={Array []}
-        placeholder="Any value"
-        value={null}
-        valueKey="value"
-      />
+      <div
+        className="css-10nd86i objectlist-current-filter__active-status"
+        id={undefined}
+        onKeyDown={[Function]}
+      >
+        <span
+          aria-atomic="true"
+          aria-live="polite"
+          className="css-1uvvha"
+          role="status"
+        >
+          0 results available.
+        </span>
+        <div
+          className="css-1aya2g8 objectlist-current-filter__active-status__control"
+          onMouseDown={[Function]}
+          onTouchEnd={[Function]}
+        >
+          <div
+            className="css-1rtrksz objectlist-current-filter__active-status__value-container"
+          >
+            <div
+              className="css-1492t68 objectlist-current-filter__active-status__placeholder"
+            >
+              Any value
+            </div>
+            <div
+              className="css-rsyb7x"
+            >
+              <div
+                className="objectlist-current-filter__active-status__input"
+                style={
+                  Object {
+                    "display": "inline-block",
+                  }
+                }
+              >
+                <input
+                  aria-activedescendant={undefined}
+                  aria-autocomplete="list"
+                  aria-busy={false}
+                  aria-describedby={undefined}
+                  aria-expanded={false}
+                  aria-haspopup={false}
+                  aria-label={undefined}
+                  aria-labelledby={undefined}
+                  aria-owns={undefined}
+                  autoCapitalize="none"
+                  autoComplete="off"
+                  autoCorrect="off"
+                  className={undefined}
+                  disabled={false}
+                  id="react-select-6-input"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  role="combobox"
+                  spellCheck="false"
+                  style={
+                    Object {
+                      "background": 0,
+                      "border": 0,
+                      "boxSizing": "content-box",
+                      "color": "inherit",
+                      "fontSize": "inherit",
+                      "opacity": 1,
+                      "outline": 0,
+                      "padding": 0,
+                      "width": "1px",
+                    }
+                  }
+                  tabIndex="0"
+                  type="text"
+                  value=""
+                />
+                <div
+                  style={
+                    Object {
+                      "height": 0,
+                      "left": 0,
+                      "overflow": "scroll",
+                      "position": "absolute",
+                      "top": 0,
+                      "visibility": "hidden",
+                      "whiteSpace": "pre",
+                    }
+                  }
+                >
+                  
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="css-1wy0on6 objectlist-current-filter__active-status__indicators"
+          >
+            <span
+              className="css-d8oujb objectlist-current-filter__active-status__indicator-separator"
+              role="presentation"
+            />
+            <div
+              className="css-1ep9fjw objectlist-current-filter__active-status__indicator objectlist-current-filter__active-status__dropdown-indicator"
+              onMouseDown={[Function]}
+              onTouchEnd={[Function]}
+              role="button"
+            >
+              <svg
+                className="css-19bqh2r"
+                focusable="false"
+                height={20}
+                role="presentation"
+                viewBox="0 0 20 20"
+                width={20}
+              >
+                <path
+                  d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
       <button
         className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
         onClick={[Function]}
@@ -1614,7 +1930,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
         className="objectlist-current-filter__filter-comparison"
       >
         <Select
-          clearable={false}
+          isClearable={false}
           onChange={[Function]}
           options={
             Array [
@@ -1636,18 +1952,128 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
           }
         />
       </div>
-      <Select.Async
-        className="objectlist-current-filter__active-status"
-        labelKey="label"
-        loadOptions={[Function]}
-        multi={true}
-        onChange={[Function]}
-        optionRenderer={null}
-        options={Array []}
-        placeholder="Any value"
-        value={null}
-        valueKey="value"
-      />
+      <div
+        className="css-10nd86i objectlist-current-filter__active-status"
+        id={undefined}
+        onKeyDown={[Function]}
+      >
+        <span
+          aria-atomic="true"
+          aria-live="polite"
+          className="css-1uvvha"
+          role="status"
+        >
+          0 results available.
+        </span>
+        <div
+          className="css-1aya2g8 objectlist-current-filter__active-status__control"
+          onMouseDown={[Function]}
+          onTouchEnd={[Function]}
+        >
+          <div
+            className="css-1rtrksz objectlist-current-filter__active-status__value-container objectlist-current-filter__active-status__value-container--is-multi"
+          >
+            <div
+              className="css-1492t68 objectlist-current-filter__active-status__placeholder"
+            >
+              Any value
+            </div>
+            <div
+              className="css-rsyb7x"
+            >
+              <div
+                className="objectlist-current-filter__active-status__input"
+                style={
+                  Object {
+                    "display": "inline-block",
+                  }
+                }
+              >
+                <input
+                  aria-activedescendant={undefined}
+                  aria-autocomplete="list"
+                  aria-busy={false}
+                  aria-describedby={undefined}
+                  aria-expanded={false}
+                  aria-haspopup={false}
+                  aria-label={undefined}
+                  aria-labelledby={undefined}
+                  aria-owns={undefined}
+                  autoCapitalize="none"
+                  autoComplete="off"
+                  autoCorrect="off"
+                  className={undefined}
+                  disabled={false}
+                  id="react-select-7-input"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  role="combobox"
+                  spellCheck="false"
+                  style={
+                    Object {
+                      "background": 0,
+                      "border": 0,
+                      "boxSizing": "content-box",
+                      "color": "inherit",
+                      "fontSize": "inherit",
+                      "opacity": 1,
+                      "outline": 0,
+                      "padding": 0,
+                      "width": "1px",
+                    }
+                  }
+                  tabIndex="0"
+                  type="text"
+                  value=""
+                />
+                <div
+                  style={
+                    Object {
+                      "height": 0,
+                      "left": 0,
+                      "overflow": "scroll",
+                      "position": "absolute",
+                      "top": 0,
+                      "visibility": "hidden",
+                      "whiteSpace": "pre",
+                    }
+                  }
+                >
+                  
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="css-1wy0on6 objectlist-current-filter__active-status__indicators"
+          >
+            <span
+              className="css-d8oujb objectlist-current-filter__active-status__indicator-separator"
+              role="presentation"
+            />
+            <div
+              className="css-1ep9fjw objectlist-current-filter__active-status__indicator objectlist-current-filter__active-status__dropdown-indicator"
+              onMouseDown={[Function]}
+              onTouchEnd={[Function]}
+              role="button"
+            >
+              <svg
+                className="css-19bqh2r"
+                focusable="false"
+                height={20}
+                role="presentation"
+                viewBox="0 0 20 20"
+                width={20}
+              >
+                <path
+                  d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
       <button
         className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
         onClick={[Function]}
@@ -1732,23 +2158,19 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
     >
       <Select
         className="objectlist-select-filter"
-        labelKey="name"
-        menuContainerStyle={
-          Object {
-            "maxHeight": "500px",
-          }
-        }
-        menuStyle={
-          Object {
-            "maxHeight": "500px",
-          }
-        }
+        getOptionLabel={[Function]}
+        getOptionValue={[Function]}
         onChange={undefined}
-        openOnFocus={true}
+        openMenuOnClick={true}
         options={Array []}
         placeholder="Add Filter"
+        styles={
+          Object {
+            "menu": [Function],
+            "menuList": [Function],
+          }
+        }
         value={null}
-        valueKey="filterKey"
       />
       <div
         className="objectlist-dropdown"
@@ -1804,11 +2226,11 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
       </label>
       <Select
         className="objectlist-current-filter__active-status"
-        labelKey="label"
+        getOptionLabel={[Function]}
+        getOptionValue={[Function]}
+        isMulti={false}
         loadOptions={undefined}
-        multi={false}
         onChange={[Function]}
-        optionRenderer={null}
         options={
           Array [
             Object {
@@ -1823,7 +2245,6 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
         }
         placeholder="Any value"
         value={null}
-        valueKey="value"
       />
       <button
         className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
@@ -2012,7 +2433,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
         className="objectlist-current-filter__filter-comparison"
       >
         <Select
-          clearable={false}
+          isClearable={false}
           onChange={[Function]}
           options={
             Array [
@@ -2085,7 +2506,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
         className="objectlist-current-filter__filter-comparison"
       >
         <Select
-          clearable={false}
+          isClearable={false}
           onChange={[Function]}
           options={
             Array [
@@ -2104,15 +2525,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
       </div>
       <Select
         className="objectlist-current-filter__active-status"
-        labelKey="label"
+        getOptionLabel={[Function]}
+        getOptionValue={[Function]}
+        isMulti={false}
         loadOptions={undefined}
-        multi={false}
         onChange={[Function]}
-        optionRenderer={null}
         options={Array []}
         placeholder="Any value"
         value={null}
-        valueKey="value"
       />
       <button
         className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
@@ -2133,7 +2553,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
         className="objectlist-current-filter__filter-comparison"
       >
         <Select
-          clearable={false}
+          isClearable={false}
           onChange={[Function]}
           options={
             Array [
@@ -2152,7 +2572,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
       </div>
       <Select
         className="objectlist-current-filter__active-status"
-        clearable={false}
+        isClearable={false}
         onChange={[Function]}
         options={
           Array [
@@ -2225,7 +2645,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
         className="objectlist-current-filter__filter-comparison"
       >
         <Select
-          clearable={false}
+          isClearable={false}
           onChange={[Function]}
           options={
             Array [
@@ -2244,15 +2664,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
       </div>
       <Select
         className="objectlist-current-filter__active-status"
-        labelKey="label"
+        getOptionLabel={[Function]}
+        getOptionValue={[Function]}
+        isMulti={true}
         loadOptions={undefined}
-        multi={true}
         onChange={[Function]}
-        optionRenderer={null}
         options={Array []}
         placeholder="Any value"
         value={null}
-        valueKey="value"
       />
       <button
         className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
@@ -2273,7 +2692,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
         className="objectlist-current-filter__filter-comparison"
       >
         <Select
-          clearable={false}
+          isClearable={false}
           onChange={[Function]}
           options={
             Array [
@@ -2344,7 +2763,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
         className="objectlist-current-filter__filter-comparison"
       >
         <Select
-          clearable={false}
+          isClearable={false}
           onChange={[Function]}
           options={
             Array [
@@ -2383,18 +2802,128 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
         RemoteChoiceFilter
         :
       </label>
-      <Select.Async
-        className="objectlist-current-filter__active-status"
-        labelKey="label"
-        loadOptions={[Function]}
-        multi={false}
-        onChange={[Function]}
-        optionRenderer={null}
-        options={Array []}
-        placeholder="Any value"
-        value={null}
-        valueKey="value"
-      />
+      <div
+        className="css-10nd86i objectlist-current-filter__active-status"
+        id={undefined}
+        onKeyDown={[Function]}
+      >
+        <span
+          aria-atomic="true"
+          aria-live="polite"
+          className="css-1uvvha"
+          role="status"
+        >
+          0 results available.
+        </span>
+        <div
+          className="css-1aya2g8 objectlist-current-filter__active-status__control"
+          onMouseDown={[Function]}
+          onTouchEnd={[Function]}
+        >
+          <div
+            className="css-1rtrksz objectlist-current-filter__active-status__value-container"
+          >
+            <div
+              className="css-1492t68 objectlist-current-filter__active-status__placeholder"
+            >
+              Any value
+            </div>
+            <div
+              className="css-rsyb7x"
+            >
+              <div
+                className="objectlist-current-filter__active-status__input"
+                style={
+                  Object {
+                    "display": "inline-block",
+                  }
+                }
+              >
+                <input
+                  aria-activedescendant={undefined}
+                  aria-autocomplete="list"
+                  aria-busy={false}
+                  aria-describedby={undefined}
+                  aria-expanded={false}
+                  aria-haspopup={false}
+                  aria-label={undefined}
+                  aria-labelledby={undefined}
+                  aria-owns={undefined}
+                  autoCapitalize="none"
+                  autoComplete="off"
+                  autoCorrect="off"
+                  className={undefined}
+                  disabled={false}
+                  id="react-select-8-input"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  role="combobox"
+                  spellCheck="false"
+                  style={
+                    Object {
+                      "background": 0,
+                      "border": 0,
+                      "boxSizing": "content-box",
+                      "color": "inherit",
+                      "fontSize": "inherit",
+                      "opacity": 1,
+                      "outline": 0,
+                      "padding": 0,
+                      "width": "1px",
+                    }
+                  }
+                  tabIndex="0"
+                  type="text"
+                  value=""
+                />
+                <div
+                  style={
+                    Object {
+                      "height": 0,
+                      "left": 0,
+                      "overflow": "scroll",
+                      "position": "absolute",
+                      "top": 0,
+                      "visibility": "hidden",
+                      "whiteSpace": "pre",
+                    }
+                  }
+                >
+                  
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="css-1wy0on6 objectlist-current-filter__active-status__indicators"
+          >
+            <span
+              className="css-d8oujb objectlist-current-filter__active-status__indicator-separator"
+              role="presentation"
+            />
+            <div
+              className="css-1ep9fjw objectlist-current-filter__active-status__indicator objectlist-current-filter__active-status__dropdown-indicator"
+              onMouseDown={[Function]}
+              onTouchEnd={[Function]}
+              role="button"
+            >
+              <svg
+                className="css-19bqh2r"
+                focusable="false"
+                height={20}
+                role="presentation"
+                viewBox="0 0 20 20"
+                width={20}
+              >
+                <path
+                  d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
       <button
         className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
         onClick={[Function]}
@@ -2414,7 +2943,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
         className="objectlist-current-filter__filter-comparison"
       >
         <Select
-          clearable={false}
+          isClearable={false}
           onChange={[Function]}
           options={
             Array [
@@ -2436,18 +2965,128 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
           }
         />
       </div>
-      <Select.Async
-        className="objectlist-current-filter__active-status"
-        labelKey="label"
-        loadOptions={[Function]}
-        multi={true}
-        onChange={[Function]}
-        optionRenderer={null}
-        options={Array []}
-        placeholder="Any value"
-        value={null}
-        valueKey="value"
-      />
+      <div
+        className="css-10nd86i objectlist-current-filter__active-status"
+        id={undefined}
+        onKeyDown={[Function]}
+      >
+        <span
+          aria-atomic="true"
+          aria-live="polite"
+          className="css-1uvvha"
+          role="status"
+        >
+          0 results available.
+        </span>
+        <div
+          className="css-1aya2g8 objectlist-current-filter__active-status__control"
+          onMouseDown={[Function]}
+          onTouchEnd={[Function]}
+        >
+          <div
+            className="css-1rtrksz objectlist-current-filter__active-status__value-container objectlist-current-filter__active-status__value-container--is-multi"
+          >
+            <div
+              className="css-1492t68 objectlist-current-filter__active-status__placeholder"
+            >
+              Any value
+            </div>
+            <div
+              className="css-rsyb7x"
+            >
+              <div
+                className="objectlist-current-filter__active-status__input"
+                style={
+                  Object {
+                    "display": "inline-block",
+                  }
+                }
+              >
+                <input
+                  aria-activedescendant={undefined}
+                  aria-autocomplete="list"
+                  aria-busy={false}
+                  aria-describedby={undefined}
+                  aria-expanded={false}
+                  aria-haspopup={false}
+                  aria-label={undefined}
+                  aria-labelledby={undefined}
+                  aria-owns={undefined}
+                  autoCapitalize="none"
+                  autoComplete="off"
+                  autoCorrect="off"
+                  className={undefined}
+                  disabled={false}
+                  id="react-select-9-input"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  role="combobox"
+                  spellCheck="false"
+                  style={
+                    Object {
+                      "background": 0,
+                      "border": 0,
+                      "boxSizing": "content-box",
+                      "color": "inherit",
+                      "fontSize": "inherit",
+                      "opacity": 1,
+                      "outline": 0,
+                      "padding": 0,
+                      "width": "1px",
+                    }
+                  }
+                  tabIndex="0"
+                  type="text"
+                  value=""
+                />
+                <div
+                  style={
+                    Object {
+                      "height": 0,
+                      "left": 0,
+                      "overflow": "scroll",
+                      "position": "absolute",
+                      "top": 0,
+                      "visibility": "hidden",
+                      "whiteSpace": "pre",
+                    }
+                  }
+                >
+                  
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="css-1wy0on6 objectlist-current-filter__active-status__indicators"
+          >
+            <span
+              className="css-d8oujb objectlist-current-filter__active-status__indicator-separator"
+              role="presentation"
+            />
+            <div
+              className="css-1ep9fjw objectlist-current-filter__active-status__indicator objectlist-current-filter__active-status__dropdown-indicator"
+              onMouseDown={[Function]}
+              onTouchEnd={[Function]}
+              role="button"
+            >
+              <svg
+                className="css-19bqh2r"
+                focusable="false"
+                height={20}
+                role="presentation"
+                viewBox="0 0 20 20"
+                width={20}
+              >
+                <path
+                  d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
       <button
         className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
         onClick={[Function]}
@@ -2516,23 +3155,19 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
     >
       <Select
         className="objectlist-select-filter"
-        labelKey="name"
-        menuContainerStyle={
-          Object {
-            "maxHeight": "500px",
-          }
-        }
-        menuStyle={
-          Object {
-            "maxHeight": "500px",
-          }
-        }
+        getOptionLabel={[Function]}
+        getOptionValue={[Function]}
         onChange={undefined}
-        openOnFocus={true}
+        openMenuOnClick={true}
         options={Array []}
         placeholder="Add Filter"
+        styles={
+          Object {
+            "menu": [Function],
+            "menuList": [Function],
+          }
+        }
         value={null}
-        valueKey="filterKey"
       />
       <div
         className="objectlist-dropdown"
@@ -2588,11 +3223,11 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
       </label>
       <Select
         className="objectlist-current-filter__active-status"
-        labelKey="label"
+        getOptionLabel={[Function]}
+        getOptionValue={[Function]}
+        isMulti={false}
         loadOptions={undefined}
-        multi={false}
         onChange={[Function]}
-        optionRenderer={null}
         options={
           Array [
             Object {
@@ -2607,7 +3242,6 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
         }
         placeholder="Any value"
         value={null}
-        valueKey="value"
       />
       <button
         className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
@@ -2796,7 +3430,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
         className="objectlist-current-filter__filter-comparison"
       >
         <Select
-          clearable={false}
+          isClearable={false}
           onChange={[Function]}
           options={
             Array [
@@ -2869,7 +3503,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
         className="objectlist-current-filter__filter-comparison"
       >
         <Select
-          clearable={false}
+          isClearable={false}
           onChange={[Function]}
           options={
             Array [
@@ -2888,15 +3522,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
       </div>
       <Select
         className="objectlist-current-filter__active-status"
-        labelKey="label"
+        getOptionLabel={[Function]}
+        getOptionValue={[Function]}
+        isMulti={false}
         loadOptions={undefined}
-        multi={false}
         onChange={[Function]}
-        optionRenderer={null}
         options={Array []}
         placeholder="Any value"
         value={null}
-        valueKey="value"
       />
       <button
         className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
@@ -2917,7 +3550,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
         className="objectlist-current-filter__filter-comparison"
       >
         <Select
-          clearable={false}
+          isClearable={false}
           onChange={[Function]}
           options={
             Array [
@@ -2936,7 +3569,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
       </div>
       <Select
         className="objectlist-current-filter__active-status"
-        clearable={false}
+        isClearable={false}
         onChange={[Function]}
         options={
           Array [
@@ -3009,7 +3642,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
         className="objectlist-current-filter__filter-comparison"
       >
         <Select
-          clearable={false}
+          isClearable={false}
           onChange={[Function]}
           options={
             Array [
@@ -3028,15 +3661,14 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
       </div>
       <Select
         className="objectlist-current-filter__active-status"
-        labelKey="label"
+        getOptionLabel={[Function]}
+        getOptionValue={[Function]}
+        isMulti={true}
         loadOptions={undefined}
-        multi={true}
         onChange={[Function]}
-        optionRenderer={null}
         options={Array []}
         placeholder="Any value"
         value={null}
-        valueKey="value"
       />
       <button
         className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
@@ -3057,7 +3689,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
         className="objectlist-current-filter__filter-comparison"
       >
         <Select
-          clearable={false}
+          isClearable={false}
           onChange={[Function]}
           options={
             Array [
@@ -3128,7 +3760,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
         className="objectlist-current-filter__filter-comparison"
       >
         <Select
-          clearable={false}
+          isClearable={false}
           onChange={[Function]}
           options={
             Array [
@@ -3167,18 +3799,128 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
         RemoteChoiceFilter
         :
       </label>
-      <Select.Async
-        className="objectlist-current-filter__active-status"
-        labelKey="label"
-        loadOptions={[Function]}
-        multi={false}
-        onChange={[Function]}
-        optionRenderer={null}
-        options={Array []}
-        placeholder="Any value"
-        value={null}
-        valueKey="value"
-      />
+      <div
+        className="css-10nd86i objectlist-current-filter__active-status"
+        id={undefined}
+        onKeyDown={[Function]}
+      >
+        <span
+          aria-atomic="true"
+          aria-live="polite"
+          className="css-1uvvha"
+          role="status"
+        >
+          0 results available.
+        </span>
+        <div
+          className="css-1aya2g8 objectlist-current-filter__active-status__control"
+          onMouseDown={[Function]}
+          onTouchEnd={[Function]}
+        >
+          <div
+            className="css-1rtrksz objectlist-current-filter__active-status__value-container"
+          >
+            <div
+              className="css-1492t68 objectlist-current-filter__active-status__placeholder"
+            >
+              Any value
+            </div>
+            <div
+              className="css-rsyb7x"
+            >
+              <div
+                className="objectlist-current-filter__active-status__input"
+                style={
+                  Object {
+                    "display": "inline-block",
+                  }
+                }
+              >
+                <input
+                  aria-activedescendant={undefined}
+                  aria-autocomplete="list"
+                  aria-busy={false}
+                  aria-describedby={undefined}
+                  aria-expanded={false}
+                  aria-haspopup={false}
+                  aria-label={undefined}
+                  aria-labelledby={undefined}
+                  aria-owns={undefined}
+                  autoCapitalize="none"
+                  autoComplete="off"
+                  autoCorrect="off"
+                  className={undefined}
+                  disabled={false}
+                  id="react-select-10-input"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  role="combobox"
+                  spellCheck="false"
+                  style={
+                    Object {
+                      "background": 0,
+                      "border": 0,
+                      "boxSizing": "content-box",
+                      "color": "inherit",
+                      "fontSize": "inherit",
+                      "opacity": 1,
+                      "outline": 0,
+                      "padding": 0,
+                      "width": "1px",
+                    }
+                  }
+                  tabIndex="0"
+                  type="text"
+                  value=""
+                />
+                <div
+                  style={
+                    Object {
+                      "height": 0,
+                      "left": 0,
+                      "overflow": "scroll",
+                      "position": "absolute",
+                      "top": 0,
+                      "visibility": "hidden",
+                      "whiteSpace": "pre",
+                    }
+                  }
+                >
+                  
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="css-1wy0on6 objectlist-current-filter__active-status__indicators"
+          >
+            <span
+              className="css-d8oujb objectlist-current-filter__active-status__indicator-separator"
+              role="presentation"
+            />
+            <div
+              className="css-1ep9fjw objectlist-current-filter__active-status__indicator objectlist-current-filter__active-status__dropdown-indicator"
+              onMouseDown={[Function]}
+              onTouchEnd={[Function]}
+              role="button"
+            >
+              <svg
+                className="css-19bqh2r"
+                focusable="false"
+                height={20}
+                role="presentation"
+                viewBox="0 0 20 20"
+                width={20}
+              >
+                <path
+                  d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
       <button
         className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
         onClick={[Function]}
@@ -3198,7 +3940,7 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
         className="objectlist-current-filter__filter-comparison"
       >
         <Select
-          clearable={false}
+          isClearable={false}
           onChange={[Function]}
           options={
             Array [
@@ -3220,18 +3962,128 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
           }
         />
       </div>
-      <Select.Async
-        className="objectlist-current-filter__active-status"
-        labelKey="label"
-        loadOptions={[Function]}
-        multi={true}
-        onChange={[Function]}
-        optionRenderer={null}
-        options={Array []}
-        placeholder="Any value"
-        value={null}
-        valueKey="value"
-      />
+      <div
+        className="css-10nd86i objectlist-current-filter__active-status"
+        id={undefined}
+        onKeyDown={[Function]}
+      >
+        <span
+          aria-atomic="true"
+          aria-live="polite"
+          className="css-1uvvha"
+          role="status"
+        >
+          0 results available.
+        </span>
+        <div
+          className="css-1aya2g8 objectlist-current-filter__active-status__control"
+          onMouseDown={[Function]}
+          onTouchEnd={[Function]}
+        >
+          <div
+            className="css-1rtrksz objectlist-current-filter__active-status__value-container objectlist-current-filter__active-status__value-container--is-multi"
+          >
+            <div
+              className="css-1492t68 objectlist-current-filter__active-status__placeholder"
+            >
+              Any value
+            </div>
+            <div
+              className="css-rsyb7x"
+            >
+              <div
+                className="objectlist-current-filter__active-status__input"
+                style={
+                  Object {
+                    "display": "inline-block",
+                  }
+                }
+              >
+                <input
+                  aria-activedescendant={undefined}
+                  aria-autocomplete="list"
+                  aria-busy={false}
+                  aria-describedby={undefined}
+                  aria-expanded={false}
+                  aria-haspopup={false}
+                  aria-label={undefined}
+                  aria-labelledby={undefined}
+                  aria-owns={undefined}
+                  autoCapitalize="none"
+                  autoComplete="off"
+                  autoCorrect="off"
+                  className={undefined}
+                  disabled={false}
+                  id="react-select-11-input"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  role="combobox"
+                  spellCheck="false"
+                  style={
+                    Object {
+                      "background": 0,
+                      "border": 0,
+                      "boxSizing": "content-box",
+                      "color": "inherit",
+                      "fontSize": "inherit",
+                      "opacity": 1,
+                      "outline": 0,
+                      "padding": 0,
+                      "width": "1px",
+                    }
+                  }
+                  tabIndex="0"
+                  type="text"
+                  value=""
+                />
+                <div
+                  style={
+                    Object {
+                      "height": 0,
+                      "left": 0,
+                      "overflow": "scroll",
+                      "position": "absolute",
+                      "top": 0,
+                      "visibility": "hidden",
+                      "whiteSpace": "pre",
+                    }
+                  }
+                >
+                  
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="css-1wy0on6 objectlist-current-filter__active-status__indicators"
+          >
+            <span
+              className="css-d8oujb objectlist-current-filter__active-status__indicator-separator"
+              role="presentation"
+            />
+            <div
+              className="css-1ep9fjw objectlist-current-filter__active-status__indicator objectlist-current-filter__active-status__dropdown-indicator"
+              onMouseDown={[Function]}
+              onTouchEnd={[Function]}
+              role="button"
+            >
+              <svg
+                className="css-19bqh2r"
+                focusable="false"
+                height={20}
+                role="presentation"
+                viewBox="0 0 20 20"
+                width={20}
+              >
+                <path
+                  d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
       <button
         className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
         onClick={[Function]}

--- a/src/actions-filters/__snapshots__/ActionsFiltersContainer.stories.storyshot
+++ b/src/actions-filters/__snapshots__/ActionsFiltersContainer.stories.storyshot
@@ -671,128 +671,17 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
         RemoteChoiceFilter
         :
       </label>
-      <div
-        className="css-10nd86i objectlist-current-filter__active-status"
-        id={undefined}
-        onKeyDown={[Function]}
-      >
-        <span
-          aria-atomic="true"
-          aria-live="polite"
-          className="css-1uvvha"
-          role="status"
-        >
-          0 results available.
-        </span>
-        <div
-          className="css-1aya2g8 objectlist-current-filter__active-status__control"
-          onMouseDown={[Function]}
-          onTouchEnd={[Function]}
-        >
-          <div
-            className="css-1rtrksz objectlist-current-filter__active-status__value-container"
-          >
-            <div
-              className="css-1492t68 objectlist-current-filter__active-status__placeholder"
-            >
-              Any value
-            </div>
-            <div
-              className="css-rsyb7x"
-            >
-              <div
-                className="objectlist-current-filter__active-status__input"
-                style={
-                  Object {
-                    "display": "inline-block",
-                  }
-                }
-              >
-                <input
-                  aria-activedescendant={undefined}
-                  aria-autocomplete="list"
-                  aria-busy={false}
-                  aria-describedby={undefined}
-                  aria-expanded={false}
-                  aria-haspopup={false}
-                  aria-label={undefined}
-                  aria-labelledby={undefined}
-                  aria-owns={undefined}
-                  autoCapitalize="none"
-                  autoComplete="off"
-                  autoCorrect="off"
-                  className={undefined}
-                  disabled={false}
-                  id="react-select-4-input"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  role="combobox"
-                  spellCheck="false"
-                  style={
-                    Object {
-                      "background": 0,
-                      "border": 0,
-                      "boxSizing": "content-box",
-                      "color": "inherit",
-                      "fontSize": "inherit",
-                      "opacity": 1,
-                      "outline": 0,
-                      "padding": 0,
-                      "width": "1px",
-                    }
-                  }
-                  tabIndex="0"
-                  type="text"
-                  value=""
-                />
-                <div
-                  style={
-                    Object {
-                      "height": 0,
-                      "left": 0,
-                      "overflow": "scroll",
-                      "position": "absolute",
-                      "top": 0,
-                      "visibility": "hidden",
-                      "whiteSpace": "pre",
-                    }
-                  }
-                >
-                  
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="css-1wy0on6 objectlist-current-filter__active-status__indicators"
-          >
-            <span
-              className="css-d8oujb objectlist-current-filter__active-status__indicator-separator"
-              role="presentation"
-            />
-            <div
-              className="css-1ep9fjw objectlist-current-filter__active-status__indicator objectlist-current-filter__active-status__dropdown-indicator"
-              onMouseDown={[Function]}
-              onTouchEnd={[Function]}
-              role="button"
-            >
-              <svg
-                className="css-19bqh2r"
-                focusable="false"
-                height={20}
-                role="presentation"
-                viewBox="0 0 20 20"
-                width={20}
-              >
-                <path
-                  d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                />
-              </svg>
-            </div>
-          </div>
-        </div>
-      </div>
+      <Select.Async
+        className="objectlist-current-filter__active-status"
+        getOptionLabel={[Function]}
+        getOptionValue={[Function]}
+        isMulti={false}
+        loadOptions={[Function]}
+        onChange={[Function]}
+        options={Array []}
+        placeholder="Any value"
+        value={null}
+      />
       <button
         className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
         onClick={[Function]}
@@ -834,128 +723,17 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
           }
         />
       </div>
-      <div
-        className="css-10nd86i objectlist-current-filter__active-status"
-        id={undefined}
-        onKeyDown={[Function]}
-      >
-        <span
-          aria-atomic="true"
-          aria-live="polite"
-          className="css-1uvvha"
-          role="status"
-        >
-          0 results available.
-        </span>
-        <div
-          className="css-1aya2g8 objectlist-current-filter__active-status__control"
-          onMouseDown={[Function]}
-          onTouchEnd={[Function]}
-        >
-          <div
-            className="css-1rtrksz objectlist-current-filter__active-status__value-container objectlist-current-filter__active-status__value-container--is-multi"
-          >
-            <div
-              className="css-1492t68 objectlist-current-filter__active-status__placeholder"
-            >
-              Any value
-            </div>
-            <div
-              className="css-rsyb7x"
-            >
-              <div
-                className="objectlist-current-filter__active-status__input"
-                style={
-                  Object {
-                    "display": "inline-block",
-                  }
-                }
-              >
-                <input
-                  aria-activedescendant={undefined}
-                  aria-autocomplete="list"
-                  aria-busy={false}
-                  aria-describedby={undefined}
-                  aria-expanded={false}
-                  aria-haspopup={false}
-                  aria-label={undefined}
-                  aria-labelledby={undefined}
-                  aria-owns={undefined}
-                  autoCapitalize="none"
-                  autoComplete="off"
-                  autoCorrect="off"
-                  className={undefined}
-                  disabled={false}
-                  id="react-select-5-input"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  role="combobox"
-                  spellCheck="false"
-                  style={
-                    Object {
-                      "background": 0,
-                      "border": 0,
-                      "boxSizing": "content-box",
-                      "color": "inherit",
-                      "fontSize": "inherit",
-                      "opacity": 1,
-                      "outline": 0,
-                      "padding": 0,
-                      "width": "1px",
-                    }
-                  }
-                  tabIndex="0"
-                  type="text"
-                  value=""
-                />
-                <div
-                  style={
-                    Object {
-                      "height": 0,
-                      "left": 0,
-                      "overflow": "scroll",
-                      "position": "absolute",
-                      "top": 0,
-                      "visibility": "hidden",
-                      "whiteSpace": "pre",
-                    }
-                  }
-                >
-                  
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="css-1wy0on6 objectlist-current-filter__active-status__indicators"
-          >
-            <span
-              className="css-d8oujb objectlist-current-filter__active-status__indicator-separator"
-              role="presentation"
-            />
-            <div
-              className="css-1ep9fjw objectlist-current-filter__active-status__indicator objectlist-current-filter__active-status__dropdown-indicator"
-              onMouseDown={[Function]}
-              onTouchEnd={[Function]}
-              role="button"
-            >
-              <svg
-                className="css-19bqh2r"
-                focusable="false"
-                height={20}
-                role="presentation"
-                viewBox="0 0 20 20"
-                width={20}
-              >
-                <path
-                  d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                />
-              </svg>
-            </div>
-          </div>
-        </div>
-      </div>
+      <Select.Async
+        className="objectlist-current-filter__active-status"
+        getOptionLabel={[Function]}
+        getOptionValue={[Function]}
+        isMulti={true}
+        loadOptions={[Function]}
+        onChange={[Function]}
+        options={Array []}
+        placeholder="Any value"
+        value={null}
+      />
       <button
         className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
         onClick={[Function]}
@@ -1789,128 +1567,17 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
         RemoteChoiceFilter
         :
       </label>
-      <div
-        className="css-10nd86i objectlist-current-filter__active-status"
-        id={undefined}
-        onKeyDown={[Function]}
-      >
-        <span
-          aria-atomic="true"
-          aria-live="polite"
-          className="css-1uvvha"
-          role="status"
-        >
-          0 results available.
-        </span>
-        <div
-          className="css-1aya2g8 objectlist-current-filter__active-status__control"
-          onMouseDown={[Function]}
-          onTouchEnd={[Function]}
-        >
-          <div
-            className="css-1rtrksz objectlist-current-filter__active-status__value-container"
-          >
-            <div
-              className="css-1492t68 objectlist-current-filter__active-status__placeholder"
-            >
-              Any value
-            </div>
-            <div
-              className="css-rsyb7x"
-            >
-              <div
-                className="objectlist-current-filter__active-status__input"
-                style={
-                  Object {
-                    "display": "inline-block",
-                  }
-                }
-              >
-                <input
-                  aria-activedescendant={undefined}
-                  aria-autocomplete="list"
-                  aria-busy={false}
-                  aria-describedby={undefined}
-                  aria-expanded={false}
-                  aria-haspopup={false}
-                  aria-label={undefined}
-                  aria-labelledby={undefined}
-                  aria-owns={undefined}
-                  autoCapitalize="none"
-                  autoComplete="off"
-                  autoCorrect="off"
-                  className={undefined}
-                  disabled={false}
-                  id="react-select-6-input"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  role="combobox"
-                  spellCheck="false"
-                  style={
-                    Object {
-                      "background": 0,
-                      "border": 0,
-                      "boxSizing": "content-box",
-                      "color": "inherit",
-                      "fontSize": "inherit",
-                      "opacity": 1,
-                      "outline": 0,
-                      "padding": 0,
-                      "width": "1px",
-                    }
-                  }
-                  tabIndex="0"
-                  type="text"
-                  value=""
-                />
-                <div
-                  style={
-                    Object {
-                      "height": 0,
-                      "left": 0,
-                      "overflow": "scroll",
-                      "position": "absolute",
-                      "top": 0,
-                      "visibility": "hidden",
-                      "whiteSpace": "pre",
-                    }
-                  }
-                >
-                  
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="css-1wy0on6 objectlist-current-filter__active-status__indicators"
-          >
-            <span
-              className="css-d8oujb objectlist-current-filter__active-status__indicator-separator"
-              role="presentation"
-            />
-            <div
-              className="css-1ep9fjw objectlist-current-filter__active-status__indicator objectlist-current-filter__active-status__dropdown-indicator"
-              onMouseDown={[Function]}
-              onTouchEnd={[Function]}
-              role="button"
-            >
-              <svg
-                className="css-19bqh2r"
-                focusable="false"
-                height={20}
-                role="presentation"
-                viewBox="0 0 20 20"
-                width={20}
-              >
-                <path
-                  d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                />
-              </svg>
-            </div>
-          </div>
-        </div>
-      </div>
+      <Select.Async
+        className="objectlist-current-filter__active-status"
+        getOptionLabel={[Function]}
+        getOptionValue={[Function]}
+        isMulti={false}
+        loadOptions={[Function]}
+        onChange={[Function]}
+        options={Array []}
+        placeholder="Any value"
+        value={null}
+      />
       <button
         className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
         onClick={[Function]}
@@ -1952,128 +1619,17 @@ exports[`Storyshots object-list/ActionsFiltersContainer has one item 1`] = `
           }
         />
       </div>
-      <div
-        className="css-10nd86i objectlist-current-filter__active-status"
-        id={undefined}
-        onKeyDown={[Function]}
-      >
-        <span
-          aria-atomic="true"
-          aria-live="polite"
-          className="css-1uvvha"
-          role="status"
-        >
-          0 results available.
-        </span>
-        <div
-          className="css-1aya2g8 objectlist-current-filter__active-status__control"
-          onMouseDown={[Function]}
-          onTouchEnd={[Function]}
-        >
-          <div
-            className="css-1rtrksz objectlist-current-filter__active-status__value-container objectlist-current-filter__active-status__value-container--is-multi"
-          >
-            <div
-              className="css-1492t68 objectlist-current-filter__active-status__placeholder"
-            >
-              Any value
-            </div>
-            <div
-              className="css-rsyb7x"
-            >
-              <div
-                className="objectlist-current-filter__active-status__input"
-                style={
-                  Object {
-                    "display": "inline-block",
-                  }
-                }
-              >
-                <input
-                  aria-activedescendant={undefined}
-                  aria-autocomplete="list"
-                  aria-busy={false}
-                  aria-describedby={undefined}
-                  aria-expanded={false}
-                  aria-haspopup={false}
-                  aria-label={undefined}
-                  aria-labelledby={undefined}
-                  aria-owns={undefined}
-                  autoCapitalize="none"
-                  autoComplete="off"
-                  autoCorrect="off"
-                  className={undefined}
-                  disabled={false}
-                  id="react-select-7-input"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  role="combobox"
-                  spellCheck="false"
-                  style={
-                    Object {
-                      "background": 0,
-                      "border": 0,
-                      "boxSizing": "content-box",
-                      "color": "inherit",
-                      "fontSize": "inherit",
-                      "opacity": 1,
-                      "outline": 0,
-                      "padding": 0,
-                      "width": "1px",
-                    }
-                  }
-                  tabIndex="0"
-                  type="text"
-                  value=""
-                />
-                <div
-                  style={
-                    Object {
-                      "height": 0,
-                      "left": 0,
-                      "overflow": "scroll",
-                      "position": "absolute",
-                      "top": 0,
-                      "visibility": "hidden",
-                      "whiteSpace": "pre",
-                    }
-                  }
-                >
-                  
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="css-1wy0on6 objectlist-current-filter__active-status__indicators"
-          >
-            <span
-              className="css-d8oujb objectlist-current-filter__active-status__indicator-separator"
-              role="presentation"
-            />
-            <div
-              className="css-1ep9fjw objectlist-current-filter__active-status__indicator objectlist-current-filter__active-status__dropdown-indicator"
-              onMouseDown={[Function]}
-              onTouchEnd={[Function]}
-              role="button"
-            >
-              <svg
-                className="css-19bqh2r"
-                focusable="false"
-                height={20}
-                role="presentation"
-                viewBox="0 0 20 20"
-                width={20}
-              >
-                <path
-                  d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                />
-              </svg>
-            </div>
-          </div>
-        </div>
-      </div>
+      <Select.Async
+        className="objectlist-current-filter__active-status"
+        getOptionLabel={[Function]}
+        getOptionValue={[Function]}
+        isMulti={true}
+        loadOptions={[Function]}
+        onChange={[Function]}
+        options={Array []}
+        placeholder="Any value"
+        value={null}
+      />
       <button
         className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
         onClick={[Function]}
@@ -2802,128 +2358,17 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
         RemoteChoiceFilter
         :
       </label>
-      <div
-        className="css-10nd86i objectlist-current-filter__active-status"
-        id={undefined}
-        onKeyDown={[Function]}
-      >
-        <span
-          aria-atomic="true"
-          aria-live="polite"
-          className="css-1uvvha"
-          role="status"
-        >
-          0 results available.
-        </span>
-        <div
-          className="css-1aya2g8 objectlist-current-filter__active-status__control"
-          onMouseDown={[Function]}
-          onTouchEnd={[Function]}
-        >
-          <div
-            className="css-1rtrksz objectlist-current-filter__active-status__value-container"
-          >
-            <div
-              className="css-1492t68 objectlist-current-filter__active-status__placeholder"
-            >
-              Any value
-            </div>
-            <div
-              className="css-rsyb7x"
-            >
-              <div
-                className="objectlist-current-filter__active-status__input"
-                style={
-                  Object {
-                    "display": "inline-block",
-                  }
-                }
-              >
-                <input
-                  aria-activedescendant={undefined}
-                  aria-autocomplete="list"
-                  aria-busy={false}
-                  aria-describedby={undefined}
-                  aria-expanded={false}
-                  aria-haspopup={false}
-                  aria-label={undefined}
-                  aria-labelledby={undefined}
-                  aria-owns={undefined}
-                  autoCapitalize="none"
-                  autoComplete="off"
-                  autoCorrect="off"
-                  className={undefined}
-                  disabled={false}
-                  id="react-select-8-input"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  role="combobox"
-                  spellCheck="false"
-                  style={
-                    Object {
-                      "background": 0,
-                      "border": 0,
-                      "boxSizing": "content-box",
-                      "color": "inherit",
-                      "fontSize": "inherit",
-                      "opacity": 1,
-                      "outline": 0,
-                      "padding": 0,
-                      "width": "1px",
-                    }
-                  }
-                  tabIndex="0"
-                  type="text"
-                  value=""
-                />
-                <div
-                  style={
-                    Object {
-                      "height": 0,
-                      "left": 0,
-                      "overflow": "scroll",
-                      "position": "absolute",
-                      "top": 0,
-                      "visibility": "hidden",
-                      "whiteSpace": "pre",
-                    }
-                  }
-                >
-                  
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="css-1wy0on6 objectlist-current-filter__active-status__indicators"
-          >
-            <span
-              className="css-d8oujb objectlist-current-filter__active-status__indicator-separator"
-              role="presentation"
-            />
-            <div
-              className="css-1ep9fjw objectlist-current-filter__active-status__indicator objectlist-current-filter__active-status__dropdown-indicator"
-              onMouseDown={[Function]}
-              onTouchEnd={[Function]}
-              role="button"
-            >
-              <svg
-                className="css-19bqh2r"
-                focusable="false"
-                height={20}
-                role="presentation"
-                viewBox="0 0 20 20"
-                width={20}
-              >
-                <path
-                  d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                />
-              </svg>
-            </div>
-          </div>
-        </div>
-      </div>
+      <Select.Async
+        className="objectlist-current-filter__active-status"
+        getOptionLabel={[Function]}
+        getOptionValue={[Function]}
+        isMulti={false}
+        loadOptions={[Function]}
+        onChange={[Function]}
+        options={Array []}
+        placeholder="Any value"
+        value={null}
+      />
       <button
         className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
         onClick={[Function]}
@@ -2965,128 +2410,17 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
           }
         />
       </div>
-      <div
-        className="css-10nd86i objectlist-current-filter__active-status"
-        id={undefined}
-        onKeyDown={[Function]}
-      >
-        <span
-          aria-atomic="true"
-          aria-live="polite"
-          className="css-1uvvha"
-          role="status"
-        >
-          0 results available.
-        </span>
-        <div
-          className="css-1aya2g8 objectlist-current-filter__active-status__control"
-          onMouseDown={[Function]}
-          onTouchEnd={[Function]}
-        >
-          <div
-            className="css-1rtrksz objectlist-current-filter__active-status__value-container objectlist-current-filter__active-status__value-container--is-multi"
-          >
-            <div
-              className="css-1492t68 objectlist-current-filter__active-status__placeholder"
-            >
-              Any value
-            </div>
-            <div
-              className="css-rsyb7x"
-            >
-              <div
-                className="objectlist-current-filter__active-status__input"
-                style={
-                  Object {
-                    "display": "inline-block",
-                  }
-                }
-              >
-                <input
-                  aria-activedescendant={undefined}
-                  aria-autocomplete="list"
-                  aria-busy={false}
-                  aria-describedby={undefined}
-                  aria-expanded={false}
-                  aria-haspopup={false}
-                  aria-label={undefined}
-                  aria-labelledby={undefined}
-                  aria-owns={undefined}
-                  autoCapitalize="none"
-                  autoComplete="off"
-                  autoCorrect="off"
-                  className={undefined}
-                  disabled={false}
-                  id="react-select-9-input"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  role="combobox"
-                  spellCheck="false"
-                  style={
-                    Object {
-                      "background": 0,
-                      "border": 0,
-                      "boxSizing": "content-box",
-                      "color": "inherit",
-                      "fontSize": "inherit",
-                      "opacity": 1,
-                      "outline": 0,
-                      "padding": 0,
-                      "width": "1px",
-                    }
-                  }
-                  tabIndex="0"
-                  type="text"
-                  value=""
-                />
-                <div
-                  style={
-                    Object {
-                      "height": 0,
-                      "left": 0,
-                      "overflow": "scroll",
-                      "position": "absolute",
-                      "top": 0,
-                      "visibility": "hidden",
-                      "whiteSpace": "pre",
-                    }
-                  }
-                >
-                  
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="css-1wy0on6 objectlist-current-filter__active-status__indicators"
-          >
-            <span
-              className="css-d8oujb objectlist-current-filter__active-status__indicator-separator"
-              role="presentation"
-            />
-            <div
-              className="css-1ep9fjw objectlist-current-filter__active-status__indicator objectlist-current-filter__active-status__dropdown-indicator"
-              onMouseDown={[Function]}
-              onTouchEnd={[Function]}
-              role="button"
-            >
-              <svg
-                className="css-19bqh2r"
-                focusable="false"
-                height={20}
-                role="presentation"
-                viewBox="0 0 20 20"
-                width={20}
-              >
-                <path
-                  d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                />
-              </svg>
-            </div>
-          </div>
-        </div>
-      </div>
+      <Select.Async
+        className="objectlist-current-filter__active-status"
+        getOptionLabel={[Function]}
+        getOptionValue={[Function]}
+        isMulti={true}
+        loadOptions={[Function]}
+        onChange={[Function]}
+        options={Array []}
+        placeholder="Any value"
+        value={null}
+      />
       <button
         className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
         onClick={[Function]}
@@ -3799,128 +3133,17 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
         RemoteChoiceFilter
         :
       </label>
-      <div
-        className="css-10nd86i objectlist-current-filter__active-status"
-        id={undefined}
-        onKeyDown={[Function]}
-      >
-        <span
-          aria-atomic="true"
-          aria-live="polite"
-          className="css-1uvvha"
-          role="status"
-        >
-          0 results available.
-        </span>
-        <div
-          className="css-1aya2g8 objectlist-current-filter__active-status__control"
-          onMouseDown={[Function]}
-          onTouchEnd={[Function]}
-        >
-          <div
-            className="css-1rtrksz objectlist-current-filter__active-status__value-container"
-          >
-            <div
-              className="css-1492t68 objectlist-current-filter__active-status__placeholder"
-            >
-              Any value
-            </div>
-            <div
-              className="css-rsyb7x"
-            >
-              <div
-                className="objectlist-current-filter__active-status__input"
-                style={
-                  Object {
-                    "display": "inline-block",
-                  }
-                }
-              >
-                <input
-                  aria-activedescendant={undefined}
-                  aria-autocomplete="list"
-                  aria-busy={false}
-                  aria-describedby={undefined}
-                  aria-expanded={false}
-                  aria-haspopup={false}
-                  aria-label={undefined}
-                  aria-labelledby={undefined}
-                  aria-owns={undefined}
-                  autoCapitalize="none"
-                  autoComplete="off"
-                  autoCorrect="off"
-                  className={undefined}
-                  disabled={false}
-                  id="react-select-10-input"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  role="combobox"
-                  spellCheck="false"
-                  style={
-                    Object {
-                      "background": 0,
-                      "border": 0,
-                      "boxSizing": "content-box",
-                      "color": "inherit",
-                      "fontSize": "inherit",
-                      "opacity": 1,
-                      "outline": 0,
-                      "padding": 0,
-                      "width": "1px",
-                    }
-                  }
-                  tabIndex="0"
-                  type="text"
-                  value=""
-                />
-                <div
-                  style={
-                    Object {
-                      "height": 0,
-                      "left": 0,
-                      "overflow": "scroll",
-                      "position": "absolute",
-                      "top": 0,
-                      "visibility": "hidden",
-                      "whiteSpace": "pre",
-                    }
-                  }
-                >
-                  
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="css-1wy0on6 objectlist-current-filter__active-status__indicators"
-          >
-            <span
-              className="css-d8oujb objectlist-current-filter__active-status__indicator-separator"
-              role="presentation"
-            />
-            <div
-              className="css-1ep9fjw objectlist-current-filter__active-status__indicator objectlist-current-filter__active-status__dropdown-indicator"
-              onMouseDown={[Function]}
-              onTouchEnd={[Function]}
-              role="button"
-            >
-              <svg
-                className="css-19bqh2r"
-                focusable="false"
-                height={20}
-                role="presentation"
-                viewBox="0 0 20 20"
-                width={20}
-              >
-                <path
-                  d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                />
-              </svg>
-            </div>
-          </div>
-        </div>
-      </div>
+      <Select.Async
+        className="objectlist-current-filter__active-status"
+        getOptionLabel={[Function]}
+        getOptionValue={[Function]}
+        isMulti={false}
+        loadOptions={[Function]}
+        onChange={[Function]}
+        options={Array []}
+        placeholder="Any value"
+        value={null}
+      />
       <button
         className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
         onClick={[Function]}
@@ -3962,128 +3185,17 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
           }
         />
       </div>
-      <div
-        className="css-10nd86i objectlist-current-filter__active-status"
-        id={undefined}
-        onKeyDown={[Function]}
-      >
-        <span
-          aria-atomic="true"
-          aria-live="polite"
-          className="css-1uvvha"
-          role="status"
-        >
-          0 results available.
-        </span>
-        <div
-          className="css-1aya2g8 objectlist-current-filter__active-status__control"
-          onMouseDown={[Function]}
-          onTouchEnd={[Function]}
-        >
-          <div
-            className="css-1rtrksz objectlist-current-filter__active-status__value-container objectlist-current-filter__active-status__value-container--is-multi"
-          >
-            <div
-              className="css-1492t68 objectlist-current-filter__active-status__placeholder"
-            >
-              Any value
-            </div>
-            <div
-              className="css-rsyb7x"
-            >
-              <div
-                className="objectlist-current-filter__active-status__input"
-                style={
-                  Object {
-                    "display": "inline-block",
-                  }
-                }
-              >
-                <input
-                  aria-activedescendant={undefined}
-                  aria-autocomplete="list"
-                  aria-busy={false}
-                  aria-describedby={undefined}
-                  aria-expanded={false}
-                  aria-haspopup={false}
-                  aria-label={undefined}
-                  aria-labelledby={undefined}
-                  aria-owns={undefined}
-                  autoCapitalize="none"
-                  autoComplete="off"
-                  autoCorrect="off"
-                  className={undefined}
-                  disabled={false}
-                  id="react-select-11-input"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  role="combobox"
-                  spellCheck="false"
-                  style={
-                    Object {
-                      "background": 0,
-                      "border": 0,
-                      "boxSizing": "content-box",
-                      "color": "inherit",
-                      "fontSize": "inherit",
-                      "opacity": 1,
-                      "outline": 0,
-                      "padding": 0,
-                      "width": "1px",
-                    }
-                  }
-                  tabIndex="0"
-                  type="text"
-                  value=""
-                />
-                <div
-                  style={
-                    Object {
-                      "height": 0,
-                      "left": 0,
-                      "overflow": "scroll",
-                      "position": "absolute",
-                      "top": 0,
-                      "visibility": "hidden",
-                      "whiteSpace": "pre",
-                    }
-                  }
-                >
-                  
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="css-1wy0on6 objectlist-current-filter__active-status__indicators"
-          >
-            <span
-              className="css-d8oujb objectlist-current-filter__active-status__indicator-separator"
-              role="presentation"
-            />
-            <div
-              className="css-1ep9fjw objectlist-current-filter__active-status__indicator objectlist-current-filter__active-status__dropdown-indicator"
-              onMouseDown={[Function]}
-              onTouchEnd={[Function]}
-              role="button"
-            >
-              <svg
-                className="css-19bqh2r"
-                focusable="false"
-                height={20}
-                role="presentation"
-                viewBox="0 0 20 20"
-                width={20}
-              >
-                <path
-                  d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                />
-              </svg>
-            </div>
-          </div>
-        </div>
-      </div>
+      <Select.Async
+        className="objectlist-current-filter__active-status"
+        getOptionLabel={[Function]}
+        getOptionValue={[Function]}
+        isMulti={true}
+        loadOptions={[Function]}
+        onChange={[Function]}
+        options={Array []}
+        placeholder="Any value"
+        value={null}
+      />
       <button
         className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
         onClick={[Function]}

--- a/src/actions-filters/__snapshots__/FiltersContainer.stories.storyshot
+++ b/src/actions-filters/__snapshots__/FiltersContainer.stories.storyshot
@@ -602,128 +602,17 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
       RemoteChoiceFilter
       :
     </label>
-    <div
-      className="css-10nd86i objectlist-current-filter__active-status"
-      id={undefined}
-      onKeyDown={[Function]}
-    >
-      <span
-        aria-atomic="true"
-        aria-live="polite"
-        className="css-1uvvha"
-        role="status"
-      >
-        0 results available.
-      </span>
-      <div
-        className="css-1aya2g8 objectlist-current-filter__active-status__control"
-        onMouseDown={[Function]}
-        onTouchEnd={[Function]}
-      >
-        <div
-          className="css-1rtrksz objectlist-current-filter__active-status__value-container"
-        >
-          <div
-            className="css-1492t68 objectlist-current-filter__active-status__placeholder"
-          >
-            Any value
-          </div>
-          <div
-            className="css-rsyb7x"
-          >
-            <div
-              className="objectlist-current-filter__active-status__input"
-              style={
-                Object {
-                  "display": "inline-block",
-                }
-              }
-            >
-              <input
-                aria-activedescendant={undefined}
-                aria-autocomplete="list"
-                aria-busy={false}
-                aria-describedby={undefined}
-                aria-expanded={false}
-                aria-haspopup={false}
-                aria-label={undefined}
-                aria-labelledby={undefined}
-                aria-owns={undefined}
-                autoCapitalize="none"
-                autoComplete="off"
-                autoCorrect="off"
-                className={undefined}
-                disabled={false}
-                id="react-select-12-input"
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                role="combobox"
-                spellCheck="false"
-                style={
-                  Object {
-                    "background": 0,
-                    "border": 0,
-                    "boxSizing": "content-box",
-                    "color": "inherit",
-                    "fontSize": "inherit",
-                    "opacity": 1,
-                    "outline": 0,
-                    "padding": 0,
-                    "width": "1px",
-                  }
-                }
-                tabIndex="0"
-                type="text"
-                value=""
-              />
-              <div
-                style={
-                  Object {
-                    "height": 0,
-                    "left": 0,
-                    "overflow": "scroll",
-                    "position": "absolute",
-                    "top": 0,
-                    "visibility": "hidden",
-                    "whiteSpace": "pre",
-                  }
-                }
-              >
-                
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="css-1wy0on6 objectlist-current-filter__active-status__indicators"
-        >
-          <span
-            className="css-d8oujb objectlist-current-filter__active-status__indicator-separator"
-            role="presentation"
-          />
-          <div
-            className="css-1ep9fjw objectlist-current-filter__active-status__indicator objectlist-current-filter__active-status__dropdown-indicator"
-            onMouseDown={[Function]}
-            onTouchEnd={[Function]}
-            role="button"
-          >
-            <svg
-              className="css-19bqh2r"
-              focusable="false"
-              height={20}
-              role="presentation"
-              viewBox="0 0 20 20"
-              width={20}
-            >
-              <path
-                d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-              />
-            </svg>
-          </div>
-        </div>
-      </div>
-    </div>
+    <Select.Async
+      className="objectlist-current-filter__active-status"
+      getOptionLabel={[Function]}
+      getOptionValue={[Function]}
+      isMulti={false}
+      loadOptions={[Function]}
+      onChange={[Function]}
+      options={Array []}
+      placeholder="Any value"
+      value={null}
+    />
     <button
       className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
       onClick={[Function]}
@@ -765,128 +654,17 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
         }
       />
     </div>
-    <div
-      className="css-10nd86i objectlist-current-filter__active-status"
-      id={undefined}
-      onKeyDown={[Function]}
-    >
-      <span
-        aria-atomic="true"
-        aria-live="polite"
-        className="css-1uvvha"
-        role="status"
-      >
-        0 results available.
-      </span>
-      <div
-        className="css-1aya2g8 objectlist-current-filter__active-status__control"
-        onMouseDown={[Function]}
-        onTouchEnd={[Function]}
-      >
-        <div
-          className="css-1rtrksz objectlist-current-filter__active-status__value-container objectlist-current-filter__active-status__value-container--is-multi"
-        >
-          <div
-            className="css-1492t68 objectlist-current-filter__active-status__placeholder"
-          >
-            Any value
-          </div>
-          <div
-            className="css-rsyb7x"
-          >
-            <div
-              className="objectlist-current-filter__active-status__input"
-              style={
-                Object {
-                  "display": "inline-block",
-                }
-              }
-            >
-              <input
-                aria-activedescendant={undefined}
-                aria-autocomplete="list"
-                aria-busy={false}
-                aria-describedby={undefined}
-                aria-expanded={false}
-                aria-haspopup={false}
-                aria-label={undefined}
-                aria-labelledby={undefined}
-                aria-owns={undefined}
-                autoCapitalize="none"
-                autoComplete="off"
-                autoCorrect="off"
-                className={undefined}
-                disabled={false}
-                id="react-select-13-input"
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                role="combobox"
-                spellCheck="false"
-                style={
-                  Object {
-                    "background": 0,
-                    "border": 0,
-                    "boxSizing": "content-box",
-                    "color": "inherit",
-                    "fontSize": "inherit",
-                    "opacity": 1,
-                    "outline": 0,
-                    "padding": 0,
-                    "width": "1px",
-                  }
-                }
-                tabIndex="0"
-                type="text"
-                value=""
-              />
-              <div
-                style={
-                  Object {
-                    "height": 0,
-                    "left": 0,
-                    "overflow": "scroll",
-                    "position": "absolute",
-                    "top": 0,
-                    "visibility": "hidden",
-                    "whiteSpace": "pre",
-                  }
-                }
-              >
-                
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="css-1wy0on6 objectlist-current-filter__active-status__indicators"
-        >
-          <span
-            className="css-d8oujb objectlist-current-filter__active-status__indicator-separator"
-            role="presentation"
-          />
-          <div
-            className="css-1ep9fjw objectlist-current-filter__active-status__indicator objectlist-current-filter__active-status__dropdown-indicator"
-            onMouseDown={[Function]}
-            onTouchEnd={[Function]}
-            role="button"
-          >
-            <svg
-              className="css-19bqh2r"
-              focusable="false"
-              height={20}
-              role="presentation"
-              viewBox="0 0 20 20"
-              width={20}
-            >
-              <path
-                d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-              />
-            </svg>
-          </div>
-        </div>
-      </div>
-    </div>
+    <Select.Async
+      className="objectlist-current-filter__active-status"
+      getOptionLabel={[Function]}
+      getOptionValue={[Function]}
+      isMulti={true}
+      loadOptions={[Function]}
+      onChange={[Function]}
+      options={Array []}
+      placeholder="Any value"
+      value={null}
+    />
     <button
       className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
       onClick={[Function]}

--- a/src/actions-filters/__snapshots__/FiltersContainer.stories.storyshot
+++ b/src/actions-filters/__snapshots__/FiltersContainer.stories.storyshot
@@ -33,6 +33,14 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
         ]
       }
       placeholder="Any value"
+      styles={
+        Object {
+          "control": [Function],
+          "dropdownIndicator": [Function],
+          "multiValue": [Function],
+          "multiValueLabel": [Function],
+        }
+      }
       value={null}
     />
     <button
@@ -248,12 +256,15 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
             },
           ]
         }
-        value={
+        styles={
           Object {
-            "label": "Exact",
-            "value": "exact",
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
           }
         }
+        value={undefined}
       />
     </div>
     <div
@@ -309,7 +320,20 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
             },
           ]
         }
-        value="is"
+        styles={
+          Object {
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
+          }
+        }
+        value={
+          Object {
+            "label": "Is",
+            "value": "is",
+          }
+        }
       />
     </div>
     <Select
@@ -321,6 +345,14 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
       onChange={[Function]}
       options={Array []}
       placeholder="Any value"
+      styles={
+        Object {
+          "control": [Function],
+          "dropdownIndicator": [Function],
+          "multiValue": [Function],
+          "multiValueLabel": [Function],
+        }
+      }
       value={null}
     />
     <button
@@ -356,7 +388,20 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
             },
           ]
         }
-        value="relative"
+        styles={
+          Object {
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
+          }
+        }
+        value={
+          Object {
+            "label": "Relative to Now",
+            "value": "relative",
+          }
+        }
       />
     </div>
     <Select
@@ -382,6 +427,14 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
             "value": "year_start",
           },
         ]
+      }
+      styles={
+        Object {
+          "control": [Function],
+          "dropdownIndicator": [Function],
+          "multiValue": [Function],
+          "multiValueLabel": [Function],
+        }
       }
     />
     <button
@@ -442,7 +495,20 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
             },
           ]
         }
-        value="is"
+        styles={
+          Object {
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
+          }
+        }
+        value={
+          Object {
+            "label": "Is",
+            "value": "is",
+          }
+        }
       />
     </div>
     <Select
@@ -454,6 +520,14 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
       onChange={[Function]}
       options={Array []}
       placeholder="Any value"
+      styles={
+        Object {
+          "control": [Function],
+          "dropdownIndicator": [Function],
+          "multiValue": [Function],
+          "multiValueLabel": [Function],
+        }
+      }
       value={null}
     />
     <button
@@ -501,7 +575,20 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
             },
           ]
         }
-        value="exact"
+        styles={
+          Object {
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
+          }
+        }
+        value={
+          Object {
+            "label": "Exact",
+            "value": "exact",
+          }
+        }
       />
     </div>
     <div
@@ -577,7 +664,20 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
             },
           ]
         }
-        value="contains"
+        styles={
+          Object {
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
+          }
+        }
+        value={
+          Object {
+            "label": "Contains",
+            "value": "contains",
+          }
+        }
       />
     </div>
     <input
@@ -611,6 +711,14 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
       onChange={[Function]}
       options={Array []}
       placeholder="Any value"
+      styles={
+        Object {
+          "control": [Function],
+          "dropdownIndicator": [Function],
+          "multiValue": [Function],
+          "multiValueLabel": [Function],
+        }
+      }
       value={null}
     />
     <button
@@ -646,12 +754,15 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
             },
           ]
         }
-        value={
+        styles={
           Object {
-            "label": "Is",
-            "value": "is",
+            "control": [Function],
+            "dropdownIndicator": [Function],
+            "multiValue": [Function],
+            "multiValueLabel": [Function],
           }
         }
+        value={undefined}
       />
     </div>
     <Select.Async
@@ -663,6 +774,14 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
       onChange={[Function]}
       options={Array []}
       placeholder="Any value"
+      styles={
+        Object {
+          "control": [Function],
+          "dropdownIndicator": [Function],
+          "multiValue": [Function],
+          "multiValueLabel": [Function],
+        }
+      }
       value={null}
     />
     <button

--- a/src/actions-filters/__snapshots__/FiltersContainer.stories.storyshot
+++ b/src/actions-filters/__snapshots__/FiltersContainer.stories.storyshot
@@ -15,11 +15,11 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
     </label>
     <Select
       className="objectlist-current-filter__active-status"
-      labelKey="label"
+      getOptionLabel={[Function]}
+      getOptionValue={[Function]}
+      isMulti={false}
       loadOptions={undefined}
-      multi={false}
       onChange={[Function]}
-      optionRenderer={null}
       options={
         Array [
           Object {
@@ -34,7 +34,6 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
       }
       placeholder="Any value"
       value={null}
-      valueKey="value"
     />
     <button
       className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
@@ -223,7 +222,7 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
       className="objectlist-current-filter__filter-comparison"
     >
       <Select
-        clearable={false}
+        isClearable={false}
         onChange={[Function]}
         options={
           Array [
@@ -296,7 +295,7 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
       className="objectlist-current-filter__filter-comparison"
     >
       <Select
-        clearable={false}
+        isClearable={false}
         onChange={[Function]}
         options={
           Array [
@@ -315,15 +314,14 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
     </div>
     <Select
       className="objectlist-current-filter__active-status"
-      labelKey="label"
+      getOptionLabel={[Function]}
+      getOptionValue={[Function]}
+      isMulti={false}
       loadOptions={undefined}
-      multi={false}
       onChange={[Function]}
-      optionRenderer={null}
       options={Array []}
       placeholder="Any value"
       value={null}
-      valueKey="value"
     />
     <button
       className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
@@ -344,7 +342,7 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
       className="objectlist-current-filter__filter-comparison"
     >
       <Select
-        clearable={false}
+        isClearable={false}
         onChange={[Function]}
         options={
           Array [
@@ -363,7 +361,7 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
     </div>
     <Select
       className="objectlist-current-filter__active-status"
-      clearable={false}
+      isClearable={false}
       onChange={[Function]}
       options={
         Array [
@@ -430,7 +428,7 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
       className="objectlist-current-filter__filter-comparison"
     >
       <Select
-        clearable={false}
+        isClearable={false}
         onChange={[Function]}
         options={
           Array [
@@ -449,15 +447,14 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
     </div>
     <Select
       className="objectlist-current-filter__active-status"
-      labelKey="label"
+      getOptionLabel={[Function]}
+      getOptionValue={[Function]}
+      isMulti={true}
       loadOptions={undefined}
-      multi={true}
       onChange={[Function]}
-      optionRenderer={null}
       options={Array []}
       placeholder="Any value"
       value={null}
-      valueKey="value"
     />
     <button
       className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
@@ -478,7 +475,7 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
       className="objectlist-current-filter__filter-comparison"
     >
       <Select
-        clearable={false}
+        isClearable={false}
         onChange={[Function]}
         options={
           Array [
@@ -566,7 +563,7 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
       className="objectlist-current-filter__filter-comparison"
     >
       <Select
-        clearable={false}
+        isClearable={false}
         onChange={[Function]}
         options={
           Array [
@@ -605,18 +602,128 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
       RemoteChoiceFilter
       :
     </label>
-    <Select.Async
-      className="objectlist-current-filter__active-status"
-      labelKey="label"
-      loadOptions={[Function]}
-      multi={false}
-      onChange={[Function]}
-      optionRenderer={null}
-      options={Array []}
-      placeholder="Any value"
-      value={null}
-      valueKey="value"
-    />
+    <div
+      className="css-10nd86i objectlist-current-filter__active-status"
+      id={undefined}
+      onKeyDown={[Function]}
+    >
+      <span
+        aria-atomic="true"
+        aria-live="polite"
+        className="css-1uvvha"
+        role="status"
+      >
+        0 results available.
+      </span>
+      <div
+        className="css-1aya2g8 objectlist-current-filter__active-status__control"
+        onMouseDown={[Function]}
+        onTouchEnd={[Function]}
+      >
+        <div
+          className="css-1rtrksz objectlist-current-filter__active-status__value-container"
+        >
+          <div
+            className="css-1492t68 objectlist-current-filter__active-status__placeholder"
+          >
+            Any value
+          </div>
+          <div
+            className="css-rsyb7x"
+          >
+            <div
+              className="objectlist-current-filter__active-status__input"
+              style={
+                Object {
+                  "display": "inline-block",
+                }
+              }
+            >
+              <input
+                aria-activedescendant={undefined}
+                aria-autocomplete="list"
+                aria-busy={false}
+                aria-describedby={undefined}
+                aria-expanded={false}
+                aria-haspopup={false}
+                aria-label={undefined}
+                aria-labelledby={undefined}
+                aria-owns={undefined}
+                autoCapitalize="none"
+                autoComplete="off"
+                autoCorrect="off"
+                className={undefined}
+                disabled={false}
+                id="react-select-12-input"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                role="combobox"
+                spellCheck="false"
+                style={
+                  Object {
+                    "background": 0,
+                    "border": 0,
+                    "boxSizing": "content-box",
+                    "color": "inherit",
+                    "fontSize": "inherit",
+                    "opacity": 1,
+                    "outline": 0,
+                    "padding": 0,
+                    "width": "1px",
+                  }
+                }
+                tabIndex="0"
+                type="text"
+                value=""
+              />
+              <div
+                style={
+                  Object {
+                    "height": 0,
+                    "left": 0,
+                    "overflow": "scroll",
+                    "position": "absolute",
+                    "top": 0,
+                    "visibility": "hidden",
+                    "whiteSpace": "pre",
+                  }
+                }
+              >
+                
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="css-1wy0on6 objectlist-current-filter__active-status__indicators"
+        >
+          <span
+            className="css-d8oujb objectlist-current-filter__active-status__indicator-separator"
+            role="presentation"
+          />
+          <div
+            className="css-1ep9fjw objectlist-current-filter__active-status__indicator objectlist-current-filter__active-status__dropdown-indicator"
+            onMouseDown={[Function]}
+            onTouchEnd={[Function]}
+            role="button"
+          >
+            <svg
+              className="css-19bqh2r"
+              focusable="false"
+              height={20}
+              role="presentation"
+              viewBox="0 0 20 20"
+              width={20}
+            >
+              <path
+                d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
     <button
       className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
       onClick={[Function]}
@@ -636,7 +743,7 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
       className="objectlist-current-filter__filter-comparison"
     >
       <Select
-        clearable={false}
+        isClearable={false}
         onChange={[Function]}
         options={
           Array [
@@ -658,18 +765,128 @@ exports[`Storyshots object-list/FiltersContainer default view 1`] = `
         }
       />
     </div>
-    <Select.Async
-      className="objectlist-current-filter__active-status"
-      labelKey="label"
-      loadOptions={[Function]}
-      multi={true}
-      onChange={[Function]}
-      optionRenderer={null}
-      options={Array []}
-      placeholder="Any value"
-      value={null}
-      valueKey="value"
-    />
+    <div
+      className="css-10nd86i objectlist-current-filter__active-status"
+      id={undefined}
+      onKeyDown={[Function]}
+    >
+      <span
+        aria-atomic="true"
+        aria-live="polite"
+        className="css-1uvvha"
+        role="status"
+      >
+        0 results available.
+      </span>
+      <div
+        className="css-1aya2g8 objectlist-current-filter__active-status__control"
+        onMouseDown={[Function]}
+        onTouchEnd={[Function]}
+      >
+        <div
+          className="css-1rtrksz objectlist-current-filter__active-status__value-container objectlist-current-filter__active-status__value-container--is-multi"
+        >
+          <div
+            className="css-1492t68 objectlist-current-filter__active-status__placeholder"
+          >
+            Any value
+          </div>
+          <div
+            className="css-rsyb7x"
+          >
+            <div
+              className="objectlist-current-filter__active-status__input"
+              style={
+                Object {
+                  "display": "inline-block",
+                }
+              }
+            >
+              <input
+                aria-activedescendant={undefined}
+                aria-autocomplete="list"
+                aria-busy={false}
+                aria-describedby={undefined}
+                aria-expanded={false}
+                aria-haspopup={false}
+                aria-label={undefined}
+                aria-labelledby={undefined}
+                aria-owns={undefined}
+                autoCapitalize="none"
+                autoComplete="off"
+                autoCorrect="off"
+                className={undefined}
+                disabled={false}
+                id="react-select-13-input"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                role="combobox"
+                spellCheck="false"
+                style={
+                  Object {
+                    "background": 0,
+                    "border": 0,
+                    "boxSizing": "content-box",
+                    "color": "inherit",
+                    "fontSize": "inherit",
+                    "opacity": 1,
+                    "outline": 0,
+                    "padding": 0,
+                    "width": "1px",
+                  }
+                }
+                tabIndex="0"
+                type="text"
+                value=""
+              />
+              <div
+                style={
+                  Object {
+                    "height": 0,
+                    "left": 0,
+                    "overflow": "scroll",
+                    "position": "absolute",
+                    "top": 0,
+                    "visibility": "hidden",
+                    "whiteSpace": "pre",
+                  }
+                }
+              >
+                
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="css-1wy0on6 objectlist-current-filter__active-status__indicators"
+        >
+          <span
+            className="css-d8oujb objectlist-current-filter__active-status__indicator-separator"
+            role="presentation"
+          />
+          <div
+            className="css-1ep9fjw objectlist-current-filter__active-status__indicator objectlist-current-filter__active-status__dropdown-indicator"
+            onMouseDown={[Function]}
+            onTouchEnd={[Function]}
+            role="button"
+          >
+            <svg
+              className="css-19bqh2r"
+              focusable="false"
+              height={20}
+              role="presentation"
+              viewBox="0 0 20 20"
+              width={20}
+            >
+              <path
+                d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
     <button
       className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
       onClick={[Function]}

--- a/src/actions-filters/__snapshots__/SelectFilters.stories.storyshot
+++ b/src/actions-filters/__snapshots__/SelectFilters.stories.storyshot
@@ -3,19 +3,10 @@
 exports[`Storyshots object-list/SelectFilters default view 1`] = `
 <Select
   className="objectlist-select-filter"
-  labelKey="name"
-  menuContainerStyle={
-    Object {
-      "maxHeight": "500px",
-    }
-  }
-  menuStyle={
-    Object {
-      "maxHeight": "500px",
-    }
-  }
+  getOptionLabel={[Function]}
+  getOptionValue={[Function]}
   onChange={[Function]}
-  openOnFocus={true}
+  openMenuOnClick={true}
   options={
     Array [
       Object {
@@ -95,7 +86,12 @@ exports[`Storyshots object-list/SelectFilters default view 1`] = `
     ]
   }
   placeholder="Add Filter"
+  styles={
+    Object {
+      "menu": [Function],
+      "menuList": [Function],
+    }
+  }
   value={null}
-  valueKey="filterKey"
 />
 `;

--- a/src/actions-filters/__snapshots__/SelectFilters.stories.storyshot
+++ b/src/actions-filters/__snapshots__/SelectFilters.stories.storyshot
@@ -88,8 +88,10 @@ exports[`Storyshots object-list/SelectFilters default view 1`] = `
   placeholder="Add Filter"
   styles={
     Object {
-      "menu": [Function],
-      "menuList": [Function],
+      "control": [Function],
+      "dropdownIndicator": [Function],
+      "multiValue": [Function],
+      "multiValueLabel": [Function],
     }
   }
   value={null}

--- a/src/actions-filters/__tests__/__snapshots__/SelectFilters.test.js.snap
+++ b/src/actions-filters/__tests__/__snapshots__/SelectFilters.test.js.snap
@@ -19,8 +19,10 @@ exports[`<SelectFilters /> Snapshot renders correctly 1`] = `
   placeholder="Add Filter"
   styles={
     Object {
-      "menu": [Function],
-      "menuList": [Function],
+      "control": [Function],
+      "dropdownIndicator": [Function],
+      "multiValue": [Function],
+      "multiValueLabel": [Function],
     }
   }
   value={null}

--- a/src/actions-filters/__tests__/__snapshots__/SelectFilters.test.js.snap
+++ b/src/actions-filters/__tests__/__snapshots__/SelectFilters.test.js.snap
@@ -3,19 +3,10 @@
 exports[`<SelectFilters /> Snapshot renders correctly 1`] = `
 <ReactSelect
   className="objectlist-select-filter"
-  labelKey="name"
-  menuContainerStyle={
-    Object {
-      "maxHeight": "500px",
-    }
-  }
-  menuStyle={
-    Object {
-      "maxHeight": "500px",
-    }
-  }
+  getOptionLabel={[Function]}
+  getOptionValue={[Function]}
   onChange={[MockFunction]}
-  openOnFocus={true}
+  openMenuOnClick={true}
   options={
     Array [
       Object {
@@ -26,7 +17,12 @@ exports[`<SelectFilters /> Snapshot renders correctly 1`] = `
     ]
   }
   placeholder="Add Filter"
+  styles={
+    Object {
+      "menu": [Function],
+      "menuList": [Function],
+    }
+  }
   value={null}
-  valueKey="filterKey"
 />
 `;

--- a/src/filters/__snapshots__/filters.stories.storyshot
+++ b/src/filters/__snapshots__/filters.stories.storyshot
@@ -12,11 +12,11 @@ exports[`Storyshots object-list/Filters BooleanFilter 1`] = `
   </label>
   <Select
     className="objectlist-current-filter__active-status"
-    labelKey="label"
+    getOptionLabel={[Function]}
+    getOptionValue={[Function]}
+    isMulti={false}
     loadOptions={undefined}
-    multi={false}
     onChange={[Function]}
-    optionRenderer={null}
     options={
       Array [
         Object {
@@ -31,7 +31,6 @@ exports[`Storyshots object-list/Filters BooleanFilter 1`] = `
     }
     placeholder="Any value"
     value={null}
-    valueKey="value"
   />
   <button
     className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
@@ -55,7 +54,7 @@ exports[`Storyshots object-list/Filters ChoiceFilter 1`] = `
     className="objectlist-current-filter__filter-comparison"
   >
     <Select
-      clearable={false}
+      isClearable={false}
       onChange={[Function]}
       options={
         Array [
@@ -74,11 +73,11 @@ exports[`Storyshots object-list/Filters ChoiceFilter 1`] = `
   </div>
   <Select
     className="objectlist-current-filter__active-status"
-    labelKey="label"
+    getOptionLabel={[Function]}
+    getOptionValue={[Function]}
+    isMulti={false}
     loadOptions={undefined}
-    multi={false}
     onChange={[Function]}
-    optionRenderer={null}
     options={
       Array [
         Object {
@@ -101,7 +100,6 @@ exports[`Storyshots object-list/Filters ChoiceFilter 1`] = `
     }
     placeholder="Any value"
     value={null}
-    valueKey="value"
   />
   <button
     className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
@@ -125,7 +123,7 @@ exports[`Storyshots object-list/Filters CurrencyFilter 1`] = `
     className="objectlist-current-filter__filter-comparison"
   >
     <Select
-      clearable={false}
+      isClearable={false}
       onChange={[Function]}
       options={
         Array [
@@ -201,7 +199,7 @@ exports[`Storyshots object-list/Filters DateFilter 1`] = `
     className="objectlist-current-filter__filter-comparison"
   >
     <Select
-      clearable={false}
+      isClearable={false}
       onChange={[Function]}
       options={
         Array [
@@ -453,7 +451,7 @@ exports[`Storyshots object-list/Filters MultiChoiceFilter 1`] = `
     className="objectlist-current-filter__filter-comparison"
   >
     <Select
-      clearable={false}
+      isClearable={false}
       onChange={[Function]}
       options={
         Array [
@@ -472,11 +470,11 @@ exports[`Storyshots object-list/Filters MultiChoiceFilter 1`] = `
   </div>
   <Select
     className="objectlist-current-filter__active-status"
-    labelKey="label"
+    getOptionLabel={[Function]}
+    getOptionValue={[Function]}
+    isMulti={true}
     loadOptions={undefined}
-    multi={true}
     onChange={[Function]}
-    optionRenderer={null}
     options={
       Array [
         Object {
@@ -499,7 +497,6 @@ exports[`Storyshots object-list/Filters MultiChoiceFilter 1`] = `
     }
     placeholder="Any value"
     value={null}
-    valueKey="value"
   />
   <button
     className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
@@ -519,18 +516,128 @@ exports[`Storyshots object-list/Filters RemoteChoiceFilter 1`] = `
     Filter by
     :
   </label>
-  <Select.Async
-    className="objectlist-current-filter__active-status"
-    labelKey="label"
-    loadOptions={[Function]}
-    multi={false}
-    onChange={[Function]}
-    optionRenderer={null}
-    options={Array []}
-    placeholder="Any value"
-    value={null}
-    valueKey="value"
-  />
+  <div
+    className="css-10nd86i objectlist-current-filter__active-status"
+    id={undefined}
+    onKeyDown={[Function]}
+  >
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      className="css-1uvvha"
+      role="status"
+    >
+      0 results available.
+    </span>
+    <div
+      className="css-1aya2g8 objectlist-current-filter__active-status__control"
+      onMouseDown={[Function]}
+      onTouchEnd={[Function]}
+    >
+      <div
+        className="css-1rtrksz objectlist-current-filter__active-status__value-container"
+      >
+        <div
+          className="css-1492t68 objectlist-current-filter__active-status__placeholder"
+        >
+          Any value
+        </div>
+        <div
+          className="css-rsyb7x"
+        >
+          <div
+            className="objectlist-current-filter__active-status__input"
+            style={
+              Object {
+                "display": "inline-block",
+              }
+            }
+          >
+            <input
+              aria-activedescendant={undefined}
+              aria-autocomplete="list"
+              aria-busy={false}
+              aria-describedby={undefined}
+              aria-expanded={false}
+              aria-haspopup={false}
+              aria-label={undefined}
+              aria-labelledby={undefined}
+              aria-owns={undefined}
+              autoCapitalize="none"
+              autoComplete="off"
+              autoCorrect="off"
+              className={undefined}
+              disabled={false}
+              id="react-select-14-input"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              role="combobox"
+              spellCheck="false"
+              style={
+                Object {
+                  "background": 0,
+                  "border": 0,
+                  "boxSizing": "content-box",
+                  "color": "inherit",
+                  "fontSize": "inherit",
+                  "opacity": 1,
+                  "outline": 0,
+                  "padding": 0,
+                  "width": "1px",
+                }
+              }
+              tabIndex="0"
+              type="text"
+              value=""
+            />
+            <div
+              style={
+                Object {
+                  "height": 0,
+                  "left": 0,
+                  "overflow": "scroll",
+                  "position": "absolute",
+                  "top": 0,
+                  "visibility": "hidden",
+                  "whiteSpace": "pre",
+                }
+              }
+            >
+              
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="css-1wy0on6 objectlist-current-filter__active-status__indicators"
+      >
+        <span
+          className="css-d8oujb objectlist-current-filter__active-status__indicator-separator"
+          role="presentation"
+        />
+        <div
+          className="css-1ep9fjw objectlist-current-filter__active-status__indicator objectlist-current-filter__active-status__dropdown-indicator"
+          onMouseDown={[Function]}
+          onTouchEnd={[Function]}
+          role="button"
+        >
+          <svg
+            className="css-19bqh2r"
+            focusable="false"
+            height={20}
+            role="presentation"
+            viewBox="0 0 20 20"
+            width={20}
+          >
+            <path
+              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
+  </div>
   <button
     className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
     onClick={[Function]}
@@ -553,7 +660,7 @@ exports[`Storyshots object-list/Filters RemoteMultiChoiceFilter 1`] = `
     className="objectlist-current-filter__filter-comparison"
   >
     <Select
-      clearable={false}
+      isClearable={false}
       onChange={[Function]}
       options={
         Array [
@@ -575,18 +682,128 @@ exports[`Storyshots object-list/Filters RemoteMultiChoiceFilter 1`] = `
       }
     />
   </div>
-  <Select.Async
-    className="objectlist-current-filter__active-status"
-    labelKey="label"
-    loadOptions={[Function]}
-    multi={true}
-    onChange={[Function]}
-    optionRenderer={null}
-    options={Array []}
-    placeholder="Any value"
-    value={null}
-    valueKey="value"
-  />
+  <div
+    className="css-10nd86i objectlist-current-filter__active-status"
+    id={undefined}
+    onKeyDown={[Function]}
+  >
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      className="css-1uvvha"
+      role="status"
+    >
+      0 results available.
+    </span>
+    <div
+      className="css-1aya2g8 objectlist-current-filter__active-status__control"
+      onMouseDown={[Function]}
+      onTouchEnd={[Function]}
+    >
+      <div
+        className="css-1rtrksz objectlist-current-filter__active-status__value-container objectlist-current-filter__active-status__value-container--is-multi"
+      >
+        <div
+          className="css-1492t68 objectlist-current-filter__active-status__placeholder"
+        >
+          Any value
+        </div>
+        <div
+          className="css-rsyb7x"
+        >
+          <div
+            className="objectlist-current-filter__active-status__input"
+            style={
+              Object {
+                "display": "inline-block",
+              }
+            }
+          >
+            <input
+              aria-activedescendant={undefined}
+              aria-autocomplete="list"
+              aria-busy={false}
+              aria-describedby={undefined}
+              aria-expanded={false}
+              aria-haspopup={false}
+              aria-label={undefined}
+              aria-labelledby={undefined}
+              aria-owns={undefined}
+              autoCapitalize="none"
+              autoComplete="off"
+              autoCorrect="off"
+              className={undefined}
+              disabled={false}
+              id="react-select-15-input"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              role="combobox"
+              spellCheck="false"
+              style={
+                Object {
+                  "background": 0,
+                  "border": 0,
+                  "boxSizing": "content-box",
+                  "color": "inherit",
+                  "fontSize": "inherit",
+                  "opacity": 1,
+                  "outline": 0,
+                  "padding": 0,
+                  "width": "1px",
+                }
+              }
+              tabIndex="0"
+              type="text"
+              value=""
+            />
+            <div
+              style={
+                Object {
+                  "height": 0,
+                  "left": 0,
+                  "overflow": "scroll",
+                  "position": "absolute",
+                  "top": 0,
+                  "visibility": "hidden",
+                  "whiteSpace": "pre",
+                }
+              }
+            >
+              
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="css-1wy0on6 objectlist-current-filter__active-status__indicators"
+      >
+        <span
+          className="css-d8oujb objectlist-current-filter__active-status__indicator-separator"
+          role="presentation"
+        />
+        <div
+          className="css-1ep9fjw objectlist-current-filter__active-status__indicator objectlist-current-filter__active-status__dropdown-indicator"
+          onMouseDown={[Function]}
+          onTouchEnd={[Function]}
+          role="button"
+        >
+          <svg
+            className="css-19bqh2r"
+            focusable="false"
+            height={20}
+            role="presentation"
+            viewBox="0 0 20 20"
+            width={20}
+          >
+            <path
+              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
+  </div>
   <button
     className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
     onClick={[Function]}
@@ -623,7 +840,7 @@ exports[`Storyshots object-list/Filters TextContainsFilter 1`] = `
     className="objectlist-current-filter__filter-comparison"
   >
     <Select
-      clearable={false}
+      isClearable={false}
       onChange={[Function]}
       options={
         Array [
@@ -669,7 +886,7 @@ exports[`Storyshots object-list/Filters/NumberSliderFilter Decimal logarithmic w
     className="objectlist-current-filter__filter-comparison"
   >
     <Select
-      clearable={false}
+      isClearable={false}
       onChange={[Function]}
       options={
         Array [
@@ -743,7 +960,7 @@ exports[`Storyshots object-list/Filters/NumberSliderFilter Decimal with fixed ra
     className="objectlist-current-filter__filter-comparison"
   >
     <Select
-      clearable={false}
+      isClearable={false}
       onChange={[Function]}
       options={
         Array [
@@ -817,7 +1034,7 @@ exports[`Storyshots object-list/Filters/NumberSliderFilter Logarithmic 1`] = `
     className="objectlist-current-filter__filter-comparison"
   >
     <Select
-      clearable={false}
+      isClearable={false}
       onChange={[Function]}
       options={
         Array [
@@ -891,7 +1108,7 @@ exports[`Storyshots object-list/Filters/NumberSliderFilter Logarithmic with diff
     className="objectlist-current-filter__filter-comparison"
   >
     <Select
-      clearable={false}
+      isClearable={false}
       onChange={[Function]}
       options={
         Array [
@@ -965,7 +1182,7 @@ exports[`Storyshots object-list/Filters/NumberSliderFilter Negative decimal loga
     className="objectlist-current-filter__filter-comparison"
   >
     <Select
-      clearable={false}
+      isClearable={false}
       onChange={[Function]}
       options={
         Array [
@@ -1039,7 +1256,7 @@ exports[`Storyshots object-list/Filters/NumberSliderFilter Standard 1`] = `
     className="objectlist-current-filter__filter-comparison"
   >
     <Select
-      clearable={false}
+      isClearable={false}
       onChange={[Function]}
       options={
         Array [

--- a/src/filters/__snapshots__/filters.stories.storyshot
+++ b/src/filters/__snapshots__/filters.stories.storyshot
@@ -516,128 +516,17 @@ exports[`Storyshots object-list/Filters RemoteChoiceFilter 1`] = `
     Filter by
     :
   </label>
-  <div
-    className="css-10nd86i objectlist-current-filter__active-status"
-    id={undefined}
-    onKeyDown={[Function]}
-  >
-    <span
-      aria-atomic="true"
-      aria-live="polite"
-      className="css-1uvvha"
-      role="status"
-    >
-      0 results available.
-    </span>
-    <div
-      className="css-1aya2g8 objectlist-current-filter__active-status__control"
-      onMouseDown={[Function]}
-      onTouchEnd={[Function]}
-    >
-      <div
-        className="css-1rtrksz objectlist-current-filter__active-status__value-container"
-      >
-        <div
-          className="css-1492t68 objectlist-current-filter__active-status__placeholder"
-        >
-          Any value
-        </div>
-        <div
-          className="css-rsyb7x"
-        >
-          <div
-            className="objectlist-current-filter__active-status__input"
-            style={
-              Object {
-                "display": "inline-block",
-              }
-            }
-          >
-            <input
-              aria-activedescendant={undefined}
-              aria-autocomplete="list"
-              aria-busy={false}
-              aria-describedby={undefined}
-              aria-expanded={false}
-              aria-haspopup={false}
-              aria-label={undefined}
-              aria-labelledby={undefined}
-              aria-owns={undefined}
-              autoCapitalize="none"
-              autoComplete="off"
-              autoCorrect="off"
-              className={undefined}
-              disabled={false}
-              id="react-select-14-input"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              role="combobox"
-              spellCheck="false"
-              style={
-                Object {
-                  "background": 0,
-                  "border": 0,
-                  "boxSizing": "content-box",
-                  "color": "inherit",
-                  "fontSize": "inherit",
-                  "opacity": 1,
-                  "outline": 0,
-                  "padding": 0,
-                  "width": "1px",
-                }
-              }
-              tabIndex="0"
-              type="text"
-              value=""
-            />
-            <div
-              style={
-                Object {
-                  "height": 0,
-                  "left": 0,
-                  "overflow": "scroll",
-                  "position": "absolute",
-                  "top": 0,
-                  "visibility": "hidden",
-                  "whiteSpace": "pre",
-                }
-              }
-            >
-              
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        className="css-1wy0on6 objectlist-current-filter__active-status__indicators"
-      >
-        <span
-          className="css-d8oujb objectlist-current-filter__active-status__indicator-separator"
-          role="presentation"
-        />
-        <div
-          className="css-1ep9fjw objectlist-current-filter__active-status__indicator objectlist-current-filter__active-status__dropdown-indicator"
-          onMouseDown={[Function]}
-          onTouchEnd={[Function]}
-          role="button"
-        >
-          <svg
-            className="css-19bqh2r"
-            focusable="false"
-            height={20}
-            role="presentation"
-            viewBox="0 0 20 20"
-            width={20}
-          >
-            <path
-              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-            />
-          </svg>
-        </div>
-      </div>
-    </div>
-  </div>
+  <Select.Async
+    className="objectlist-current-filter__active-status"
+    getOptionLabel={[Function]}
+    getOptionValue={[Function]}
+    isMulti={false}
+    loadOptions={[Function]}
+    onChange={[Function]}
+    options={Array []}
+    placeholder="Any value"
+    value={null}
+  />
   <button
     className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
     onClick={[Function]}
@@ -682,128 +571,17 @@ exports[`Storyshots object-list/Filters RemoteMultiChoiceFilter 1`] = `
       }
     />
   </div>
-  <div
-    className="css-10nd86i objectlist-current-filter__active-status"
-    id={undefined}
-    onKeyDown={[Function]}
-  >
-    <span
-      aria-atomic="true"
-      aria-live="polite"
-      className="css-1uvvha"
-      role="status"
-    >
-      0 results available.
-    </span>
-    <div
-      className="css-1aya2g8 objectlist-current-filter__active-status__control"
-      onMouseDown={[Function]}
-      onTouchEnd={[Function]}
-    >
-      <div
-        className="css-1rtrksz objectlist-current-filter__active-status__value-container objectlist-current-filter__active-status__value-container--is-multi"
-      >
-        <div
-          className="css-1492t68 objectlist-current-filter__active-status__placeholder"
-        >
-          Any value
-        </div>
-        <div
-          className="css-rsyb7x"
-        >
-          <div
-            className="objectlist-current-filter__active-status__input"
-            style={
-              Object {
-                "display": "inline-block",
-              }
-            }
-          >
-            <input
-              aria-activedescendant={undefined}
-              aria-autocomplete="list"
-              aria-busy={false}
-              aria-describedby={undefined}
-              aria-expanded={false}
-              aria-haspopup={false}
-              aria-label={undefined}
-              aria-labelledby={undefined}
-              aria-owns={undefined}
-              autoCapitalize="none"
-              autoComplete="off"
-              autoCorrect="off"
-              className={undefined}
-              disabled={false}
-              id="react-select-15-input"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              role="combobox"
-              spellCheck="false"
-              style={
-                Object {
-                  "background": 0,
-                  "border": 0,
-                  "boxSizing": "content-box",
-                  "color": "inherit",
-                  "fontSize": "inherit",
-                  "opacity": 1,
-                  "outline": 0,
-                  "padding": 0,
-                  "width": "1px",
-                }
-              }
-              tabIndex="0"
-              type="text"
-              value=""
-            />
-            <div
-              style={
-                Object {
-                  "height": 0,
-                  "left": 0,
-                  "overflow": "scroll",
-                  "position": "absolute",
-                  "top": 0,
-                  "visibility": "hidden",
-                  "whiteSpace": "pre",
-                }
-              }
-            >
-              
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        className="css-1wy0on6 objectlist-current-filter__active-status__indicators"
-      >
-        <span
-          className="css-d8oujb objectlist-current-filter__active-status__indicator-separator"
-          role="presentation"
-        />
-        <div
-          className="css-1ep9fjw objectlist-current-filter__active-status__indicator objectlist-current-filter__active-status__dropdown-indicator"
-          onMouseDown={[Function]}
-          onTouchEnd={[Function]}
-          role="button"
-        >
-          <svg
-            className="css-19bqh2r"
-            focusable="false"
-            height={20}
-            role="presentation"
-            viewBox="0 0 20 20"
-            width={20}
-          >
-            <path
-              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-            />
-          </svg>
-        </div>
-      </div>
-    </div>
-  </div>
+  <Select.Async
+    className="objectlist-current-filter__active-status"
+    getOptionLabel={[Function]}
+    getOptionValue={[Function]}
+    isMulti={true}
+    loadOptions={[Function]}
+    onChange={[Function]}
+    options={Array []}
+    placeholder="Any value"
+    value={null}
+  />
   <button
     className="objectlist-button objectlist-button--delete objectlist-button--icon objectlist-button--borderless"
     onClick={[Function]}

--- a/src/filters/__snapshots__/filters.stories.storyshot
+++ b/src/filters/__snapshots__/filters.stories.storyshot
@@ -30,6 +30,14 @@ exports[`Storyshots object-list/Filters BooleanFilter 1`] = `
       ]
     }
     placeholder="Any value"
+    styles={
+      Object {
+        "control": [Function],
+        "dropdownIndicator": [Function],
+        "multiValue": [Function],
+        "multiValueLabel": [Function],
+      }
+    }
     value={null}
   />
   <button
@@ -68,7 +76,20 @@ exports[`Storyshots object-list/Filters ChoiceFilter 1`] = `
           },
         ]
       }
-      value="is"
+      styles={
+        Object {
+          "control": [Function],
+          "dropdownIndicator": [Function],
+          "multiValue": [Function],
+          "multiValueLabel": [Function],
+        }
+      }
+      value={
+        Object {
+          "label": "Is",
+          "value": "is",
+        }
+      }
     />
   </div>
   <Select
@@ -99,6 +120,14 @@ exports[`Storyshots object-list/Filters ChoiceFilter 1`] = `
       ]
     }
     placeholder="Any value"
+    styles={
+      Object {
+        "control": [Function],
+        "dropdownIndicator": [Function],
+        "multiValue": [Function],
+        "multiValueLabel": [Function],
+      }
+    }
     value={null}
   />
   <button
@@ -149,12 +178,15 @@ exports[`Storyshots object-list/Filters CurrencyFilter 1`] = `
           },
         ]
       }
-      value={
+      styles={
         Object {
-          "label": "Exact",
-          "value": "exact",
+          "control": [Function],
+          "dropdownIndicator": [Function],
+          "multiValue": [Function],
+          "multiValueLabel": [Function],
         }
       }
+      value={undefined}
     />
   </div>
   <div
@@ -213,7 +245,20 @@ exports[`Storyshots object-list/Filters DateFilter 1`] = `
           },
         ]
       }
-      value="fixed"
+      styles={
+        Object {
+          "control": [Function],
+          "dropdownIndicator": [Function],
+          "multiValue": [Function],
+          "multiValueLabel": [Function],
+        }
+      }
+      value={
+        Object {
+          "label": "Fixed Date",
+          "value": "fixed",
+        }
+      }
     />
   </div>
   <div
@@ -465,7 +510,20 @@ exports[`Storyshots object-list/Filters MultiChoiceFilter 1`] = `
           },
         ]
       }
-      value="is"
+      styles={
+        Object {
+          "control": [Function],
+          "dropdownIndicator": [Function],
+          "multiValue": [Function],
+          "multiValueLabel": [Function],
+        }
+      }
+      value={
+        Object {
+          "label": "Is",
+          "value": "is",
+        }
+      }
     />
   </div>
   <Select
@@ -496,6 +554,14 @@ exports[`Storyshots object-list/Filters MultiChoiceFilter 1`] = `
       ]
     }
     placeholder="Any value"
+    styles={
+      Object {
+        "control": [Function],
+        "dropdownIndicator": [Function],
+        "multiValue": [Function],
+        "multiValueLabel": [Function],
+      }
+    }
     value={null}
   />
   <button
@@ -525,6 +591,14 @@ exports[`Storyshots object-list/Filters RemoteChoiceFilter 1`] = `
     onChange={[Function]}
     options={Array []}
     placeholder="Any value"
+    styles={
+      Object {
+        "control": [Function],
+        "dropdownIndicator": [Function],
+        "multiValue": [Function],
+        "multiValueLabel": [Function],
+      }
+    }
     value={null}
   />
   <button
@@ -563,12 +637,15 @@ exports[`Storyshots object-list/Filters RemoteMultiChoiceFilter 1`] = `
           },
         ]
       }
-      value={
+      styles={
         Object {
-          "label": "Is",
-          "value": "is",
+          "control": [Function],
+          "dropdownIndicator": [Function],
+          "multiValue": [Function],
+          "multiValueLabel": [Function],
         }
       }
+      value={undefined}
     />
   </div>
   <Select.Async
@@ -580,6 +657,14 @@ exports[`Storyshots object-list/Filters RemoteMultiChoiceFilter 1`] = `
     onChange={[Function]}
     options={Array []}
     placeholder="Any value"
+    styles={
+      Object {
+        "control": [Function],
+        "dropdownIndicator": [Function],
+        "multiValue": [Function],
+        "multiValueLabel": [Function],
+      }
+    }
     value={null}
   />
   <button
@@ -632,7 +717,20 @@ exports[`Storyshots object-list/Filters TextContainsFilter 1`] = `
           },
         ]
       }
-      value="contains"
+      styles={
+        Object {
+          "control": [Function],
+          "dropdownIndicator": [Function],
+          "multiValue": [Function],
+          "multiValueLabel": [Function],
+        }
+      }
+      value={
+        Object {
+          "label": "Contains",
+          "value": "contains",
+        }
+      }
     />
   </div>
   <input
@@ -690,7 +788,20 @@ exports[`Storyshots object-list/Filters/NumberSliderFilter Decimal logarithmic w
           },
         ]
       }
-      value="exact"
+      styles={
+        Object {
+          "control": [Function],
+          "dropdownIndicator": [Function],
+          "multiValue": [Function],
+          "multiValueLabel": [Function],
+        }
+      }
+      value={
+        Object {
+          "label": "Exact",
+          "value": "exact",
+        }
+      }
     />
   </div>
   <div
@@ -764,7 +875,20 @@ exports[`Storyshots object-list/Filters/NumberSliderFilter Decimal with fixed ra
           },
         ]
       }
-      value="exact"
+      styles={
+        Object {
+          "control": [Function],
+          "dropdownIndicator": [Function],
+          "multiValue": [Function],
+          "multiValueLabel": [Function],
+        }
+      }
+      value={
+        Object {
+          "label": "Exact",
+          "value": "exact",
+        }
+      }
     />
   </div>
   <div
@@ -838,7 +962,20 @@ exports[`Storyshots object-list/Filters/NumberSliderFilter Logarithmic 1`] = `
           },
         ]
       }
-      value="exact"
+      styles={
+        Object {
+          "control": [Function],
+          "dropdownIndicator": [Function],
+          "multiValue": [Function],
+          "multiValueLabel": [Function],
+        }
+      }
+      value={
+        Object {
+          "label": "Exact",
+          "value": "exact",
+        }
+      }
     />
   </div>
   <div
@@ -912,7 +1049,20 @@ exports[`Storyshots object-list/Filters/NumberSliderFilter Logarithmic with diff
           },
         ]
       }
-      value="exact"
+      styles={
+        Object {
+          "control": [Function],
+          "dropdownIndicator": [Function],
+          "multiValue": [Function],
+          "multiValueLabel": [Function],
+        }
+      }
+      value={
+        Object {
+          "label": "Exact",
+          "value": "exact",
+        }
+      }
     />
   </div>
   <div
@@ -986,7 +1136,20 @@ exports[`Storyshots object-list/Filters/NumberSliderFilter Negative decimal loga
           },
         ]
       }
-      value="exact"
+      styles={
+        Object {
+          "control": [Function],
+          "dropdownIndicator": [Function],
+          "multiValue": [Function],
+          "multiValueLabel": [Function],
+        }
+      }
+      value={
+        Object {
+          "label": "Exact",
+          "value": "exact",
+        }
+      }
     />
   </div>
   <div
@@ -1060,7 +1223,20 @@ exports[`Storyshots object-list/Filters/NumberSliderFilter Standard 1`] = `
           },
         ]
       }
-      value="exact"
+      styles={
+        Object {
+          "control": [Function],
+          "dropdownIndicator": [Function],
+          "multiValue": [Function],
+          "multiValueLabel": [Function],
+        }
+      }
+      value={
+        Object {
+          "label": "Exact",
+          "value": "exact",
+        }
+      }
     />
   </div>
   <div

--- a/src/filters/types/Choice.js
+++ b/src/filters/types/Choice.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import Select from 'react-select'
+
+import Select from '../../utils/Select'
 
 /**
  * Filter input for choice values

--- a/src/filters/types/Date.js
+++ b/src/filters/types/Date.js
@@ -2,7 +2,7 @@ import React from 'react'
 import moment from 'moment'
 import PropTypes from 'prop-types'
 
-import Select from 'react-select'
+import Select from '../../utils/Select'
 
 import DayPickerInput from 'react-day-picker/DayPickerInput'
 import {

--- a/src/filters/types/__tests__/__snapshots__/Choice.test.js.snap
+++ b/src/filters/types/__tests__/__snapshots__/Choice.test.js.snap
@@ -3,86 +3,86 @@
 exports[`Choice Snapshots renders default 1`] = `
 <Select
   className="objectlist-current-filter__active-status"
-  labelKey="label"
+  getOptionLabel={[Function]}
+  getOptionValue={[Function]}
+  isMulti={false}
   loadOptions={undefined}
-  multi={false}
   onChange={[Function]}
-  optionRenderer={null}
   options={Array []}
   placeholder="Any value"
   value={44}
-  valueKey="value"
 />
 `;
 
 exports[`Choice Snapshots renders with custom label key 1`] = `
 <Select
   className="objectlist-current-filter__active-status"
-  labelKey="bob"
+  getOptionLabel={[Function]}
+  getOptionValue={[Function]}
+  isMulti={false}
   loadOptions={undefined}
-  multi={false}
   onChange={[Function]}
-  optionRenderer={null}
   options={Array []}
   placeholder="Any value"
   value={44}
-  valueKey="value"
 />
 `;
 
 exports[`Choice Snapshots renders with custom option renderer 1`] = `
 <Select
   className="objectlist-current-filter__active-status"
-  labelKey="bob"
+  components={
+    Object {
+      "Option": [Function],
+    }
+  }
+  getOptionLabel={[Function]}
+  getOptionValue={[Function]}
+  isMulti={false}
   loadOptions={undefined}
-  multi={false}
   onChange={[Function]}
-  optionRenderer={[Function]}
   options={Array []}
   placeholder="Any value"
   value={44}
-  valueKey="value"
 />
 `;
 
 exports[`Choice Snapshots renders with custom value key 1`] = `
 <Select
   className="objectlist-current-filter__active-status"
-  labelKey="label"
+  getOptionLabel={[Function]}
+  getOptionValue={[Function]}
+  isMulti={false}
   loadOptions={undefined}
-  multi={false}
   onChange={[Function]}
-  optionRenderer={null}
   options={Array []}
   placeholder="Any value"
   value={44}
-  valueKey="bob"
 />
 `;
 
 exports[`Choice Snapshots renders with multiple choice 1`] = `
 <Select
   className="objectlist-current-filter__active-status"
-  labelKey="label"
+  getOptionLabel={[Function]}
+  getOptionValue={[Function]}
+  isMulti={true}
   loadOptions={undefined}
-  multi={true}
   onChange={[Function]}
-  optionRenderer={null}
   options={Array []}
   placeholder="Any value"
   value={44}
-  valueKey="value"
 />
 `;
 
 exports[`Choice Snapshots renders with options 1`] = `
 <Select
   className="objectlist-current-filter__active-status"
-  labelKey="label"
+  getOptionLabel={[Function]}
+  getOptionValue={[Function]}
+  isMulti={false}
   loadOptions={undefined}
-  multi={false}
   onChange={[Function]}
-  optionRenderer={null}
   options={
     Array [
       Object {
@@ -93,36 +93,144 @@ exports[`Choice Snapshots renders with options 1`] = `
   }
   placeholder="Any value"
   value={44}
-  valueKey="value"
 />
 `;
 
 exports[`Choice Snapshots renders with placeholder 1`] = `
 <Select
   className="objectlist-current-filter__active-status"
-  labelKey="label"
+  getOptionLabel={[Function]}
+  getOptionValue={[Function]}
+  isMulti={false}
   loadOptions={undefined}
-  multi={false}
   onChange={[Function]}
-  optionRenderer={null}
   options={Array []}
   placeholder="Testing testing"
   value={44}
-  valueKey="value"
 />
 `;
 
 exports[`Choice Snapshots renders with remote options 1`] = `
-<Select.Async
-  className="objectlist-current-filter__active-status"
-  labelKey="label"
-  loadOptions={[MockFunction]}
-  multi={false}
-  onChange={[Function]}
-  optionRenderer={null}
-  options={Array []}
-  placeholder="Any value"
-  value={44}
-  valueKey="value"
-/>
+<div
+  className="css-10nd86i objectlist-current-filter__active-status"
+  id={undefined}
+  onKeyDown={[Function]}
+>
+  <span
+    aria-atomic="true"
+    aria-live="polite"
+    className="css-1uvvha"
+    role="status"
+  >
+    0 results available.
+  </span>
+  <div
+    className="css-1aya2g8 objectlist-current-filter__active-status__control"
+    onMouseDown={[Function]}
+    onTouchEnd={[Function]}
+  >
+    <div
+      className="css-1rtrksz objectlist-current-filter__active-status__value-container"
+    >
+      <div
+        className="css-1492t68 objectlist-current-filter__active-status__placeholder"
+      >
+        Any value
+      </div>
+      <div
+        className="css-rsyb7x"
+      >
+        <div
+          className="objectlist-current-filter__active-status__input"
+          style={
+            Object {
+              "display": "inline-block",
+            }
+          }
+        >
+          <input
+            aria-activedescendant={undefined}
+            aria-autocomplete="list"
+            aria-busy={false}
+            aria-describedby={undefined}
+            aria-expanded={false}
+            aria-haspopup={false}
+            aria-label={undefined}
+            aria-labelledby={undefined}
+            aria-owns={undefined}
+            autoCapitalize="none"
+            autoComplete="off"
+            autoCorrect="off"
+            className={undefined}
+            disabled={false}
+            id="react-select-2-input"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            role="combobox"
+            spellCheck="false"
+            style={
+              Object {
+                "background": 0,
+                "border": 0,
+                "boxSizing": "content-box",
+                "color": "inherit",
+                "fontSize": "inherit",
+                "opacity": 1,
+                "outline": 0,
+                "padding": 0,
+                "width": "1px",
+              }
+            }
+            tabIndex="0"
+            type="text"
+            value=""
+          />
+          <div
+            style={
+              Object {
+                "height": 0,
+                "left": 0,
+                "overflow": "scroll",
+                "position": "absolute",
+                "top": 0,
+                "visibility": "hidden",
+                "whiteSpace": "pre",
+              }
+            }
+          >
+            
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="css-1wy0on6 objectlist-current-filter__active-status__indicators"
+    >
+      <span
+        className="css-d8oujb objectlist-current-filter__active-status__indicator-separator"
+        role="presentation"
+      />
+      <div
+        className="css-1ep9fjw objectlist-current-filter__active-status__indicator objectlist-current-filter__active-status__dropdown-indicator"
+        onMouseDown={[Function]}
+        onTouchEnd={[Function]}
+        role="button"
+      >
+        <svg
+          className="css-19bqh2r"
+          focusable="false"
+          height={20}
+          role="presentation"
+          viewBox="0 0 20 20"
+          width={20}
+        >
+          <path
+            d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+          />
+        </svg>
+      </div>
+    </div>
+  </div>
+</div>
 `;

--- a/src/filters/types/__tests__/__snapshots__/Choice.test.js.snap
+++ b/src/filters/types/__tests__/__snapshots__/Choice.test.js.snap
@@ -111,126 +111,15 @@ exports[`Choice Snapshots renders with placeholder 1`] = `
 `;
 
 exports[`Choice Snapshots renders with remote options 1`] = `
-<div
-  className="css-10nd86i objectlist-current-filter__active-status"
-  id={undefined}
-  onKeyDown={[Function]}
->
-  <span
-    aria-atomic="true"
-    aria-live="polite"
-    className="css-1uvvha"
-    role="status"
-  >
-    0 results available.
-  </span>
-  <div
-    className="css-1aya2g8 objectlist-current-filter__active-status__control"
-    onMouseDown={[Function]}
-    onTouchEnd={[Function]}
-  >
-    <div
-      className="css-1rtrksz objectlist-current-filter__active-status__value-container"
-    >
-      <div
-        className="css-1492t68 objectlist-current-filter__active-status__placeholder"
-      >
-        Any value
-      </div>
-      <div
-        className="css-rsyb7x"
-      >
-        <div
-          className="objectlist-current-filter__active-status__input"
-          style={
-            Object {
-              "display": "inline-block",
-            }
-          }
-        >
-          <input
-            aria-activedescendant={undefined}
-            aria-autocomplete="list"
-            aria-busy={false}
-            aria-describedby={undefined}
-            aria-expanded={false}
-            aria-haspopup={false}
-            aria-label={undefined}
-            aria-labelledby={undefined}
-            aria-owns={undefined}
-            autoCapitalize="none"
-            autoComplete="off"
-            autoCorrect="off"
-            className={undefined}
-            disabled={false}
-            id="react-select-2-input"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            role="combobox"
-            spellCheck="false"
-            style={
-              Object {
-                "background": 0,
-                "border": 0,
-                "boxSizing": "content-box",
-                "color": "inherit",
-                "fontSize": "inherit",
-                "opacity": 1,
-                "outline": 0,
-                "padding": 0,
-                "width": "1px",
-              }
-            }
-            tabIndex="0"
-            type="text"
-            value=""
-          />
-          <div
-            style={
-              Object {
-                "height": 0,
-                "left": 0,
-                "overflow": "scroll",
-                "position": "absolute",
-                "top": 0,
-                "visibility": "hidden",
-                "whiteSpace": "pre",
-              }
-            }
-          >
-            
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="css-1wy0on6 objectlist-current-filter__active-status__indicators"
-    >
-      <span
-        className="css-d8oujb objectlist-current-filter__active-status__indicator-separator"
-        role="presentation"
-      />
-      <div
-        className="css-1ep9fjw objectlist-current-filter__active-status__indicator objectlist-current-filter__active-status__dropdown-indicator"
-        onMouseDown={[Function]}
-        onTouchEnd={[Function]}
-        role="button"
-      >
-        <svg
-          className="css-19bqh2r"
-          focusable="false"
-          height={20}
-          role="presentation"
-          viewBox="0 0 20 20"
-          width={20}
-        >
-          <path
-            d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-          />
-        </svg>
-      </div>
-    </div>
-  </div>
-</div>
+<Select.Async
+  className="objectlist-current-filter__active-status"
+  getOptionLabel={[Function]}
+  getOptionValue={[Function]}
+  isMulti={false}
+  loadOptions={[MockFunction]}
+  onChange={[Function]}
+  options={Array []}
+  placeholder="Any value"
+  value={44}
+/>
 `;

--- a/src/filters/types/__tests__/__snapshots__/Choice.test.js.snap
+++ b/src/filters/types/__tests__/__snapshots__/Choice.test.js.snap
@@ -10,6 +10,14 @@ exports[`Choice Snapshots renders default 1`] = `
   onChange={[Function]}
   options={Array []}
   placeholder="Any value"
+  styles={
+    Object {
+      "control": [Function],
+      "dropdownIndicator": [Function],
+      "multiValue": [Function],
+      "multiValueLabel": [Function],
+    }
+  }
   value={44}
 />
 `;
@@ -24,6 +32,14 @@ exports[`Choice Snapshots renders with custom label key 1`] = `
   onChange={[Function]}
   options={Array []}
   placeholder="Any value"
+  styles={
+    Object {
+      "control": [Function],
+      "dropdownIndicator": [Function],
+      "multiValue": [Function],
+      "multiValueLabel": [Function],
+    }
+  }
   value={44}
 />
 `;
@@ -43,6 +59,14 @@ exports[`Choice Snapshots renders with custom option renderer 1`] = `
   onChange={[Function]}
   options={Array []}
   placeholder="Any value"
+  styles={
+    Object {
+      "control": [Function],
+      "dropdownIndicator": [Function],
+      "multiValue": [Function],
+      "multiValueLabel": [Function],
+    }
+  }
   value={44}
 />
 `;
@@ -57,6 +81,14 @@ exports[`Choice Snapshots renders with custom value key 1`] = `
   onChange={[Function]}
   options={Array []}
   placeholder="Any value"
+  styles={
+    Object {
+      "control": [Function],
+      "dropdownIndicator": [Function],
+      "multiValue": [Function],
+      "multiValueLabel": [Function],
+    }
+  }
   value={44}
 />
 `;
@@ -71,6 +103,14 @@ exports[`Choice Snapshots renders with multiple choice 1`] = `
   onChange={[Function]}
   options={Array []}
   placeholder="Any value"
+  styles={
+    Object {
+      "control": [Function],
+      "dropdownIndicator": [Function],
+      "multiValue": [Function],
+      "multiValueLabel": [Function],
+    }
+  }
   value={44}
 />
 `;
@@ -92,6 +132,14 @@ exports[`Choice Snapshots renders with options 1`] = `
     ]
   }
   placeholder="Any value"
+  styles={
+    Object {
+      "control": [Function],
+      "dropdownIndicator": [Function],
+      "multiValue": [Function],
+      "multiValueLabel": [Function],
+    }
+  }
   value={44}
 />
 `;
@@ -106,6 +154,14 @@ exports[`Choice Snapshots renders with placeholder 1`] = `
   onChange={[Function]}
   options={Array []}
   placeholder="Testing testing"
+  styles={
+    Object {
+      "control": [Function],
+      "dropdownIndicator": [Function],
+      "multiValue": [Function],
+      "multiValueLabel": [Function],
+    }
+  }
   value={44}
 />
 `;
@@ -120,6 +176,14 @@ exports[`Choice Snapshots renders with remote options 1`] = `
   onChange={[Function]}
   options={Array []}
   placeholder="Any value"
+  styles={
+    Object {
+      "control": [Function],
+      "dropdownIndicator": [Function],
+      "multiValue": [Function],
+      "multiValueLabel": [Function],
+    }
+  }
   value={44}
 />
 `;

--- a/src/filters/types/__tests__/__snapshots__/Date.test.js.snap
+++ b/src/filters/types/__tests__/__snapshots__/Date.test.js.snap
@@ -27,7 +27,7 @@ exports[`Date Snapshots has custom input format 1`] = `
 exports[`Date Snapshots has custom relative date options 1`] = `
 <Select
   className="objectlist-current-filter__active-status"
-  clearable={false}
+  isClearable={false}
   onChange={[Function]}
   options={
     Array [
@@ -99,7 +99,7 @@ exports[`Date Snapshots renders default 1`] = `
 exports[`Date Snapshots renders with relative comparison 1`] = `
 <Select
   className="objectlist-current-filter__active-status"
-  clearable={false}
+  isClearable={false}
   onChange={[Function]}
   options={
     Array [

--- a/src/filters/types/__tests__/__snapshots__/Date.test.js.snap
+++ b/src/filters/types/__tests__/__snapshots__/Date.test.js.snap
@@ -45,6 +45,14 @@ exports[`Date Snapshots has custom relative date options 1`] = `
       },
     ]
   }
+  styles={
+    Object {
+      "control": [Function],
+      "dropdownIndicator": [Function],
+      "multiValue": [Function],
+      "multiValueLabel": [Function],
+    }
+  }
 />
 `;
 
@@ -120,6 +128,14 @@ exports[`Date Snapshots renders with relative comparison 1`] = `
         "value": "year_start",
       },
     ]
+  }
+  styles={
+    Object {
+      "control": [Function],
+      "dropdownIndicator": [Function],
+      "multiValue": [Function],
+      "multiValueLabel": [Function],
+    }
   }
 />
 `;

--- a/src/filters/utils/FilterComparison.js
+++ b/src/filters/utils/FilterComparison.js
@@ -20,7 +20,7 @@ class FilterComparison extends React.Component {
       <div className="objectlist-current-filter__filter-comparison">
         <Select
           options={options}
-          value={value}
+          value={options.find(x => x.value === value)}
           onChange={this.handleChange}
           clearable={false}
         />

--- a/src/filters/utils/FilterComparison.js
+++ b/src/filters/utils/FilterComparison.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import Select from 'react-select'
+import Select from '../../utils/Select'
 
 class FilterComparison extends React.Component {
   static propTypes = {

--- a/src/filters/utils/__tests__/__snapshots__/FilterComparison.test.js.snap
+++ b/src/filters/utils/__tests__/__snapshots__/FilterComparison.test.js.snap
@@ -15,7 +15,20 @@ exports[`FilterComparison Snapshots renders default 1`] = `
         },
       ]
     }
-    value="test"
+    styles={
+      Object {
+        "control": [Function],
+        "dropdownIndicator": [Function],
+        "multiValue": [Function],
+        "multiValueLabel": [Function],
+      }
+    }
+    value={
+      Object {
+        "label": "Test This",
+        "value": "test",
+      }
+    }
   />
 </div>
 `;

--- a/src/filters/utils/__tests__/__snapshots__/FilterComparison.test.js.snap
+++ b/src/filters/utils/__tests__/__snapshots__/FilterComparison.test.js.snap
@@ -5,7 +5,7 @@ exports[`FilterComparison Snapshots renders default 1`] = `
   className="objectlist-current-filter__filter-comparison"
 >
   <Select
-    clearable={false}
+    isClearable={false}
     onChange={[Function]}
     options={
       Array [

--- a/src/main.sass
+++ b/src/main.sass
@@ -1,4 +1,3 @@
-@import 'node_modules/react-select/dist/react-select'
 @import 'node_modules/font-awesome/css/font-awesome.min'
 @import 'node_modules/react-month-picker/css/month-picker'
 @import 'node_modules/react-day-picker/lib/style'

--- a/src/utils/Select.js
+++ b/src/utils/Select.js
@@ -85,6 +85,7 @@ class Select extends React.Component {
       multi: ['isMulti'],
       clearable: ['isClearable'],
       openOnFocus: ['openMenuOnClick'],
+      cache: ['cacheOptions'],
     })
 
     // Component overrides are a bit more difficult, and can't be
@@ -99,7 +100,29 @@ class Select extends React.Component {
     }
 
     // Style overrides are a bit trickier too.
-    const styles = {}
+    const styles = {
+      control: (base, state) => ({
+        ...base,
+        backgroundColor: '#fff',
+        minHeight: 0,
+      }),
+      dropdownIndicator: (base, state) => ({
+        ...base,
+        paddingTop: 0,
+        paddingBottom: 0,
+      }),
+      multiValue: (base, state) => ({
+        ...base,
+        backgroundColor: 'rgba(0,126,255,0.08)',
+        border: '1px solid rgba(0,126,255,0.24)',
+        color: '#007eff',
+      }),
+      multiValueLabel: (base, state) => ({
+        ...base,
+        color: '#007eff',
+        borderRight: '1px solid rgba(0,126,255,0.24)',
+      }),
+    }
     if (menuStyle) {
       styles.menu = ({base}) => ({...base, ...menuStyle})
     }

--- a/src/utils/Select.js
+++ b/src/utils/Select.js
@@ -60,12 +60,11 @@ function convertProps(props, transforms) {
  */
 class Select extends React.Component {
   static propTypes = {
-    ...ReactAsyncSelect.propTypes,
-    ...ReactSelect.propTypes,
     isAsync: PropTypes.bool,
     optionRenderer: PropTypes.func,
     menuStyle: PropTypes.object,
     menuContainerStyle: PropTypes.object,
+    value: PropTypes.any,
   }
 
   render() {

--- a/src/utils/Select.js
+++ b/src/utils/Select.js
@@ -60,6 +60,8 @@ function convertProps(props, transforms) {
  */
 class Select extends React.Component {
   static propTypes = {
+    ...ReactAsyncSelect.propTypes,
+    ...ReactSelect.propTypes,
     isAsync: PropTypes.bool,
     optionRenderer: PropTypes.func,
     menuStyle: PropTypes.object,

--- a/src/utils/Select.js
+++ b/src/utils/Select.js
@@ -1,0 +1,123 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import ReactSelect from 'react-select'
+import ReactAsyncSelect from 'react-select/lib/Async'
+
+// A searchable set of props to ignore when checking for
+// unknown props.
+const KNOWN_PROPS = new Set([
+  'options', 'loadOptions', 'value', 'onChange',
+  'placeholder', 'className',
+])
+
+/**
+ * Convert a set of props according to an object of transforms.
+ *
+ * A helper function to assist in translating props from one format
+ * to another. The transforms are an object whose keys are the
+ * source prop name, and whose values are an array with two
+ * elements. The first is the name of the destination prop, the
+ * second is a function that returns the new prop value. The
+ * function takes the source prop value.
+ *
+ * @returns The transformed props.
+ */
+function convertProps(props, transforms) {
+  const nextProps = {}
+  for (const [src, [dst, op]] of Object.entries(transforms)) {
+    const value = props[src]
+    if (value !== undefined) {
+      nextProps[dst] = op ? op(value) : value
+    }
+  }
+
+  // Complain loudly if there are any props that we've not
+  // been able to understand.
+  for (const attr of Object.keys(props)) {
+    if (KNOWN_PROPS.has(attr)) {
+      nextProps[attr] = props[attr]
+    } else if (!transforms.hasOwnProperty(attr)) {
+      throw new Error(
+        `Unknown prop during wrapping of react-select v1 to v2: ${attr}`
+      )
+    }
+  }
+
+  return nextProps
+}
+
+/**
+ * A thin wrapper around react-select.
+ *
+ * This wrapper makes it easy to shift between versions of
+ * react-select. We tended to use react-select in many different
+ * places, meaning if the API changed we'd need to update our
+ * code everywhere. This way we can keep an internally consistent
+ * interface and change this wrapper only.
+ *
+ * The current mapping defined here is that for converting from
+ * react-select v1 to v2.
+ */
+class Select extends React.Component {
+  static propTypes = {
+    isAsync: PropTypes.bool,
+    optionRenderer: PropTypes.func,
+    menuStyle: PropTypes.object,
+    menuContainerStyle: PropTypes.object,
+  }
+
+  render() {
+    const {
+      isAsync = false,
+      menuStyle,
+      menuContainerStyle,
+      optionRenderer,
+      ...otherProps
+    } = this.props
+
+    // Convert props semi-automatically.
+    const nextProps = convertProps(otherProps, {
+      valueKey: ['getOptionValue', v => o => o[v]],
+      labelKey: ['getOptionLabel', v => o => o[v]],
+      disabled: ['isDisabled'],
+      multi: ['isMulti'],
+      clearable: ['isClearable'],
+      openOnFocus: ['openMenuOnClick'],
+    })
+
+    // Component overrides are a bit more difficult, and can't be
+    // perfectly mapped. We'll need to update our code to work with
+    // V2.
+    const components = {}
+    if (optionRenderer) {
+      components.Option = props => optionRenderer(props)
+    }
+    if (Object.keys(components).length > 0) {
+      nextProps.components = components
+    }
+
+    // Style overrides are a bit trickier too.
+    const styles = {}
+    if (menuStyle) {
+      styles.menu = ({base}) => ({...base, ...menuStyle})
+    }
+    if (menuContainerStyle) {
+      styles.menuList = ({base}) => ({...base, ...menuContainerStyle})
+    }
+    if (Object.keys(styles).length > 0) {
+      nextProps.styles = styles
+    }
+
+    const Component = isAsync ? ReactAsyncSelect : ReactSelect
+    return (
+      <Component {...nextProps} />
+    )
+  }
+}
+
+const AsyncSelect = props =>
+  <Select {...props} isAsync />
+
+Select.Async = AsyncSelect
+
+export default Select

--- a/src/utils/Select.stories.js
+++ b/src/utils/Select.stories.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { withInfo } from '@storybook/addon-info'
+
+import Select from './Select'
+
+storiesOf('object-list/Utils/Select', module)
+  .addDecorator((story, context) => withInfo(
+    'Wrapper for react-select to ensure consistency'
+  )(story)(context))
+  .add('has custom menu style', () => (
+    <Select menuStyle={{border: '5px dashed blue'}} />
+  ))
+  .add('has custom menu container style', () => (
+    <Select menuContainerStyle={{border: '5px solid red'}} />
+  ))

--- a/src/utils/__snapshots__/Select.stories.storyshot
+++ b/src/utils/__snapshots__/Select.stories.storyshot
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots object-list/Utils/Select has custom menu container style 1`] = `
+<Select
+  styles={
+    Object {
+      "control": [Function],
+      "dropdownIndicator": [Function],
+      "menuList": [Function],
+      "multiValue": [Function],
+      "multiValueLabel": [Function],
+    }
+  }
+/>
+`;
+
+exports[`Storyshots object-list/Utils/Select has custom menu style 1`] = `
+<Select
+  styles={
+    Object {
+      "control": [Function],
+      "dropdownIndicator": [Function],
+      "menu": [Function],
+      "multiValue": [Function],
+      "multiValueLabel": [Function],
+    }
+  }
+/>
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2506,7 +2506,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.4, classnames@^2.2.5:
+classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
@@ -3300,7 +3300,7 @@ dom-converter@~0.1:
   dependencies:
     utila "~0.3"
 
-dom-helpers@^3.2.0:
+dom-helpers@^3.2.0, dom-helpers@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
 
@@ -3448,7 +3448,7 @@ emotion-theming@^9.1.2:
   dependencies:
     hoist-non-react-statics "^2.3.1"
 
-emotion@^9.1.3:
+emotion@^9.1.2, emotion@^9.1.3:
   version "9.1.3"
   resolved "https://registry.yarnpkg.com/emotion/-/emotion-9.1.3.tgz#e9b3e897ba3d5c0aff5628b0008a8993fa9c0937"
   dependencies:
@@ -8022,7 +8022,7 @@ react-icons@^2.2.7:
   dependencies:
     react-icon-base "2.1.0"
 
-react-input-autosize@^2.1.2:
+react-input-autosize@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.1.tgz#ec428fa15b1592994fb5f9aa15bb1eb6baf420f8"
   dependencies:
@@ -8071,13 +8071,16 @@ react-reconciler@^0.7.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-select@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-1.2.1.tgz#a2fe58a569eb14dcaa6543816260b97e538120d1"
+react-select@^2.0.0-beta.6:
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-2.0.0-beta.6.tgz#87ac27831f348cb9535dfd825534934adcfb7e97"
   dependencies:
-    classnames "^2.2.4"
-    prop-types "^15.5.8"
-    react-input-autosize "^2.1.2"
+    classnames "^2.2.5"
+    emotion "^9.1.2"
+    prop-types "^15.6.0"
+    raf "^3.4.0"
+    react-input-autosize "^2.2.1"
+    react-transition-group "^2.2.1"
 
 react-split-pane@^0.1.77:
   version "0.1.77"
@@ -8120,6 +8123,14 @@ react-transition-group@^1.1.2:
     loose-envify "^1.3.1"
     prop-types "^15.5.6"
     warning "^3.0.0"
+
+react-transition-group@^2.2.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.3.1.tgz#31d611b33e143a5e0f2d94c348e026a0f3b474b6"
+  dependencies:
+    dom-helpers "^3.3.1"
+    loose-envify "^1.3.1"
+    prop-types "^15.6.1"
 
 react-treebeard@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Workforce is upgrading to `react-select` v2, and so we need to bump `react-object-list` too. I've used the same approach as for Workforce; create a thin wrapper that manages converting the API from v1 to v2 for us, so we don't have to change each usage of `react-select`.

I've noticed that a couple of strange warnings appear in the console as a result of prop types:

![image](https://user-images.githubusercontent.com/561722/41071689-cb79ad18-6a3c-11e8-802c-e79bbf1779f4.png)

![image](https://user-images.githubusercontent.com/561722/41071698-dc16e3c0-6a3c-11e8-9dd9-9242f3e316ef.png)

It looks like we're passing undefined to a prop type definition somewhere, but that seems pretty strange to me. Probably need someone more familiar with how this package works to take a look.

There were a lot of snapshot tests that needed updating, I went through them and couldn't spot anything wrong.