### PR TITLE
Use search bar styling similar to old api list

### DIFF
--- a/src/main.sass
+++ b/src/main.sass
@@ -199,7 +199,6 @@ $input-height: 36px - $spacing - ($border-width * 2)
   // permanent search filter
   .objectlist-input
     height: auto
-    line-height: 2em
 
 .objectlist-row--right
   justify-content: flex-end
@@ -232,6 +231,7 @@ $input-height: 36px - $spacing - ($border-width * 2)
 
 .objectlist-button--favourites
   margin-left: $spacing
+  line-height: inherit
 
 .objectlist-button--icon
   padding-right: $spacing
@@ -269,12 +269,9 @@ $input-height: 36px - $spacing - ($border-width * 2)
     .Select-control
       border-radius: 4px
   .Select-control
-    line-height: 2em
     padding: $spacing / 2 $spacing
   .Select-placeholder
     margin-left: 1.5em
-    padding: $spacing / 2
-    line-height: 2em
   .Select-input:before
     margin-right: 0.5em
     content: "\f0b0"


### PR DESCRIPTION
Change search bar to be thinner, similar to the old api list

![localhost_properties_list__ordering page 1 status active 2csetup 2conhold](https://user-images.githubusercontent.com/19770543/41132868-ef785384-6b06-11e8-99d4-c64b3e4e5a80.png)
