### PR TITLE
Month component should send a moment on text change, not string

### DIFF
--- a/src/filters/types/Month.js
+++ b/src/filters/types/Month.js
@@ -50,7 +50,7 @@ class Month extends React.Component {
     this.setState(() => ({textValue: textValue}))
     const parsedMonth = moment(textValue, this.props.format)
     if (parsedMonth.isValid()) {
-      monthValue = parsedMonth.format('x')
+      monthValue = parsedMonth
     } else {
       monthValue = null
     }

--- a/src/filters/types/__tests__/Month.test.js
+++ b/src/filters/types/__tests__/Month.test.js
@@ -56,7 +56,7 @@ describe('Month', () => {
             value: 'Jan 2016',
           },
         }
-        const monthValue = Moment(instance.refs.textInput.value, instance.props.format).format('x')
+        const monthValue = Moment(instance.refs.textInput.value, instance.props.format)
         instance.handleTextChange()
         expect(instance.state.textValue).toBe(instance.refs.textInput.value)
         expect(baseProps.onChange).toHaveBeenCalledWith(monthValue)


### PR DESCRIPTION
This is breaking the list when a user tries to enter text for the month value