### PR TITLE
UP-1700 Use strict parsing in Month.js handleTextChange

### DIFF
--- a/src/filters/types/Month.js
+++ b/src/filters/types/Month.js
@@ -48,7 +48,8 @@ class Month extends React.Component {
     const textValue = this.refs.textInput.value
     let monthValue
     this.setState(() => ({textValue: textValue}))
-    const parsedMonth = moment(textValue, this.props.format)
+    // use the moment option strict=true to prevent excessive preemptive parsing
+    const parsedMonth = moment(textValue, this.props.format, true)
     if (parsedMonth.isValid()) {
       monthValue = parsedMonth
     } else {

--- a/src/filters/types/__tests__/Month.test.js
+++ b/src/filters/types/__tests__/Month.test.js
@@ -56,7 +56,7 @@ describe('Month', () => {
             value: 'Jan 2016',
           },
         }
-        const monthValue = Moment(instance.refs.textInput.value, instance.props.format)
+        const monthValue = Moment(instance.refs.textInput.value, instance.props.format, true) // strict=true
         instance.handleTextChange()
         expect(instance.state.textValue).toBe(instance.refs.textInput.value)
         expect(baseProps.onChange).toHaveBeenCalledWith(monthValue)


### PR DESCRIPTION
The function is parsing dates from input preemptively, often with results that are not sensible.  For example, if the format is MMM YYYY and the number '1' is entered in the input, the value will be parsed as `Jan 0001`.  If the user wishes to correct this and deletes the last digit, the date is immediately parsed as `Jan 0000`