### PR TITLE
Only show select/deselect-all when selectItems fn is provided

### DIFF
--- a/src/ObjectList.js
+++ b/src/ObjectList.js
@@ -167,8 +167,8 @@ class ObjectList extends Component {
           loadFavourite={loadFavourite}
 
           selection={selection}
-          selectAll={this.selectAll}
-          deselectAll={this.deselectAll}
+          selectAll={selectItems && this.selectAll}
+          deselectAll={selectItems && this.deselectAll}
           numSelected={numSelected}
           customActions={customActions}
         />

--- a/src/ObjectList.stories.js
+++ b/src/ObjectList.stories.js
@@ -135,6 +135,7 @@ storiesOf('object-list', module)
         searchKey="search"
         removeFilter={action('removeFilter')}
         customActions={[downloadSomething, aButton]}
+        selectItems={action('selecting items')}
       />)
   })
   .add('has error', () => (

--- a/src/__snapshots__/ObjectList.stories.storyshot
+++ b/src/__snapshots__/ObjectList.stories.storyshot
@@ -4166,6 +4166,17 @@ exports[`Storyshots object-list has everything 1`] = `
       >
         <tr>
           <th
+            className="objectlist-table__th objectlist-table__th--border-bottom objectlist-table__th--selector"
+            rowSpan={1}
+          >
+            <input
+              checked={true}
+              className="objectlist-table__checkbox"
+              onChange={[Function]}
+              type="checkbox"
+            />
+          </th>
+          <th
             className="objectlist-table__th objectlist-table__th--border-bottom "
             colSpan={undefined}
             rowSpan={1}
@@ -4231,6 +4242,16 @@ exports[`Storyshots object-list has everything 1`] = `
           <td
             className="objectlist-table__td"
           >
+            <input
+              checked={true}
+              className="objectlist-table__checkbox"
+              onChange={[Function]}
+              type="checkbox"
+            />
+          </td>
+          <td
+            className="objectlist-table__td"
+          >
             Bob
           </td>
           <td
@@ -4248,6 +4269,16 @@ exports[`Storyshots object-list has everything 1`] = `
           className="objectlist-table__row"
           onClick={null}
         >
+          <td
+            className="objectlist-table__td"
+          >
+            <input
+              checked={true}
+              className="objectlist-table__checkbox"
+              onChange={[Function]}
+              type="checkbox"
+            />
+          </td>
           <td
             className="objectlist-table__td"
           >
@@ -4271,6 +4302,16 @@ exports[`Storyshots object-list has everything 1`] = `
           <td
             className="objectlist-table__td"
           >
+            <input
+              checked={true}
+              className="objectlist-table__checkbox"
+              onChange={[Function]}
+              type="checkbox"
+            />
+          </td>
+          <td
+            className="objectlist-table__td"
+          >
             Jack
           </td>
           <td
@@ -4288,6 +4329,16 @@ exports[`Storyshots object-list has everything 1`] = `
           className="objectlist-table__row"
           onClick={null}
         >
+          <td
+            className="objectlist-table__td"
+          >
+            <input
+              checked={true}
+              className="objectlist-table__checkbox"
+              onChange={[Function]}
+              type="checkbox"
+            />
+          </td>
           <td
             className="objectlist-table__td"
           >
@@ -4311,6 +4362,16 @@ exports[`Storyshots object-list has everything 1`] = `
           <td
             className="objectlist-table__td"
           >
+            <input
+              checked={true}
+              className="objectlist-table__checkbox"
+              onChange={[Function]}
+              type="checkbox"
+            />
+          </td>
+          <td
+            className="objectlist-table__td"
+          >
             Eva
           </td>
           <td
@@ -4328,6 +4389,16 @@ exports[`Storyshots object-list has everything 1`] = `
           className="objectlist-table__row"
           onClick={null}
         >
+          <td
+            className="objectlist-table__td"
+          >
+            <input
+              checked={true}
+              className="objectlist-table__checkbox"
+              onChange={[Function]}
+              type="checkbox"
+            />
+          </td>
           <td
             className="objectlist-table__td"
           >
@@ -4351,6 +4422,16 @@ exports[`Storyshots object-list has everything 1`] = `
           <td
             className="objectlist-table__td"
           >
+            <input
+              checked={true}
+              className="objectlist-table__checkbox"
+              onChange={[Function]}
+              type="checkbox"
+            />
+          </td>
+          <td
+            className="objectlist-table__td"
+          >
             Dan
           </td>
           <td
@@ -4368,6 +4449,16 @@ exports[`Storyshots object-list has everything 1`] = `
           className="objectlist-table__row"
           onClick={null}
         >
+          <td
+            className="objectlist-table__td"
+          >
+            <input
+              checked={true}
+              className="objectlist-table__checkbox"
+              onChange={[Function]}
+              type="checkbox"
+            />
+          </td>
           <td
             className="objectlist-table__td"
           >
@@ -4391,6 +4482,16 @@ exports[`Storyshots object-list has everything 1`] = `
           <td
             className="objectlist-table__td"
           >
+            <input
+              checked={true}
+              className="objectlist-table__checkbox"
+              onChange={[Function]}
+              type="checkbox"
+            />
+          </td>
+          <td
+            className="objectlist-table__td"
+          >
             Wayne
           </td>
           <td
@@ -4408,6 +4509,16 @@ exports[`Storyshots object-list has everything 1`] = `
           className="objectlist-table__row"
           onClick={null}
         >
+          <td
+            className="objectlist-table__td"
+          >
+            <input
+              checked={true}
+              className="objectlist-table__checkbox"
+              onChange={[Function]}
+              type="checkbox"
+            />
+          </td>
           <td
             className="objectlist-table__td"
           >
@@ -4431,6 +4542,16 @@ exports[`Storyshots object-list has everything 1`] = `
           <td
             className="objectlist-table__td"
           >
+            <input
+              checked={true}
+              className="objectlist-table__checkbox"
+              onChange={[Function]}
+              type="checkbox"
+            />
+          </td>
+          <td
+            className="objectlist-table__td"
+          >
             Nina
           </td>
           <td
@@ -4448,6 +4569,16 @@ exports[`Storyshots object-list has everything 1`] = `
           className="objectlist-table__row"
           onClick={null}
         >
+          <td
+            className="objectlist-table__td"
+          >
+            <input
+              checked={true}
+              className="objectlist-table__checkbox"
+              onChange={[Function]}
+              type="checkbox"
+            />
+          </td>
           <td
             className="objectlist-table__td"
           >

--- a/src/actions-filters/ActionsFiltersContainer.stories.js
+++ b/src/actions-filters/ActionsFiltersContainer.stories.js
@@ -70,6 +70,7 @@ storiesOf('object-list/ActionsFiltersContainer', module)
         updateFilter={action('Update filter')}
         removeFilter={action('Remove filter')}
         customActions={[downloadSomething, aButton]}
+        deselectAll={action('Select all items')}
       />
     )
   }).add('has search', () => {

--- a/src/actions-filters/SelectAllAction.js
+++ b/src/actions-filters/SelectAllAction.js
@@ -28,7 +28,7 @@ class SelectAllAction extends Component {
   }
 
   render() {
-    const {selectAll, count, numSelected, itemPluralName, itemCount} = this.props
+    const {selectAll, count, numSelected, itemPluralName, itemCount, deselectAll} = this.props
     let selectAllLink
     if (selectAll && count > 0 && numSelected < count && numSelected >= itemCount) {
       selectAllLink = (
@@ -42,7 +42,7 @@ class SelectAllAction extends Component {
       )
     }
     let deselectLink
-    if (numSelected > 0) {
+    if (deselectAll && numSelected > 0) {
       deselectLink = (
         <a
           className="objectlist-link"

--- a/src/actions-filters/__snapshots__/ActionsFiltersContainer.stories.storyshot
+++ b/src/actions-filters/__snapshots__/ActionsFiltersContainer.stories.storyshot
@@ -910,17 +910,6 @@ exports[`Storyshots object-list/ActionsFiltersContainer default view 1`] = `
       >
         573,489 octopi found
       </span>
-      <div
-        className="objectlist-row"
-      >
-        <a
-          className="objectlist-link"
-          href="#"
-          onClick={[Function]}
-        >
-          Clear selection
-        </a>
-      </div>
     </div>
     <div
       className="objectlist-column"
@@ -2898,17 +2887,6 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search 1`] = `
       >
         573,489 dogs found
       </span>
-      <div
-        className="objectlist-row"
-      >
-        <a
-          className="objectlist-link"
-          href="#"
-          onClick={[Function]}
-        >
-          Clear selection
-        </a>
-      </div>
     </div>
     <div
       className="objectlist-column"
@@ -3831,17 +3809,6 @@ exports[`Storyshots object-list/ActionsFiltersContainer has search with value 1`
       >
         573,489 mouses found
       </span>
-      <div
-        className="objectlist-row"
-      >
-        <a
-          className="objectlist-link"
-          href="#"
-          onClick={[Function]}
-        >
-          Clear selection
-        </a>
-      </div>
     </div>
     <div
       className="objectlist-column"

--- a/src/actions-filters/__tests__/SelectAllAction.test.js
+++ b/src/actions-filters/__tests__/SelectAllAction.test.js
@@ -14,6 +14,7 @@ describe('<SelectAllAction />', () => {
         count: 5,
         numSelected: 3,
         itemCount: 3,
+        deselectAll: jest.fn(),
       }
       snapshotTest(<SelectAllAction {...props} />)
     })
@@ -22,6 +23,7 @@ describe('<SelectAllAction />', () => {
         count: 5,
         numSelected: 2,
         itemCount: 3,
+        deselectAll: jest.fn(),
       }
       snapshotTest(<SelectAllAction {...props} />)
     })
@@ -30,6 +32,7 @@ describe('<SelectAllAction />', () => {
         count: 5,
         numSelected: 5,
         itemCount: 3,
+        deselectAll: jest.fn(),
       }
       snapshotTest(<SelectAllAction {...props} />)
     })
@@ -40,6 +43,7 @@ describe('<SelectAllAction />', () => {
         numSelected: 3,
         itemCount: 3,
         itemPluralName: 'kitties',
+        deselectAll: jest.fn(),
       }
       snapshotTest(<SelectAllAction {...props} />)
     })


### PR DESCRIPTION
Previously `Select All` or `Deselect All` links were provided even when the function they call was not implemented.

Hide these buttons unless `selectItems` is explicitly passed through as a prop