### PR TITLE
Remove font setting on react-object-list

### DIFF
--- a/src/colours.sass
+++ b/src/colours.sass
@@ -1,5 +1,5 @@
 $link-color: blue
-$primary-button-color: #337ab7
+$primary-button-color: #00A19C
 $global-background-color: white
 $button-text-color: rgb(70, 70, 70)
 $placeholder-color: #aaa
@@ -9,8 +9,8 @@ $text-muted-color: #999
 $icon-color: black
 $slider-shadow-dark-color: #555
 $slider-shadow-light-color: #333
-$active-colour: #337ab7
-$nav-link-colour: #337ab7
+$active-colour: #00A19C
+$nav-link-colour: #00A19C
 $nav-active-colour: #6da5d6
 $nav-color-disabled: rgb(164, 164, 164)
 $table-row-background: rgba(0, 0, 0, 0.02)

--- a/src/main.sass
+++ b/src/main.sass
@@ -406,7 +406,6 @@ $input-height: 36px - $spacing - ($border-width * 2)
 .objectlist-table
   min-width: 100%
   border-collapse: collapse
-  font-family: $font
   [role="button"]
     cursor: pointer
 


### PR DESCRIPTION
Remove font setting on the react-object-table enabling us to overwrite it when importing the library

PBI:
![Screen Shot 2019-06-20 at 9 24 06 am](https://user-images.githubusercontent.com/48265941/59807893-356af180-933d-11e9-8162-c2801a2bbfa7.png)
